### PR TITLE
Make project vars optional & add fallback logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,21 +31,36 @@ If I run `dbt build -s model_2+`, the following happens:
 In short, your selected models are available in your `dev` environment with all that lovely `prod` quality!
 
 ## Setup
-After installing the package, first add the following variables to `dbt_project.yml`:
+
+### 1. Required variables
+
+After installing the package you'll need to add some variables to `dbt_project.yml`.
+
+Set either of `upstream_prod_schema` or `upstream_prod_database` to tell the package where to find production data. Open `profiles.yml` and set the relevant variables for your setup:
+
+- If dev and prod are in **different schemas in the same database**, set `upstream_prod_schema` to the `schema` value of your prod target.
+- If dev and prod are in **different logical databases**, set `upstream_prod_database` to the `database` value of your prod target.
+
+### 2. Optional variables
+- `upstream_prod_enabled`: Disables the package when False. Defaults to True.
+- `upstream_prod_fallback`: When True, models will use the default target when a prod version doesn't exist (useful when changing multiple tables at once). Defaults to False.
+- `upstream_prod_disabled_targets`: List of targets where the package should be disabled.
+
+**Example**
+
+I use Snowflake and each developer has a separate database with identically-named schemas. Here's how I have configured my project:
 
 ```yml
-# Example dbt_project.yml
+# dbt_project.yml
 vars:
-  # Required - these should match the prod target from profiles.yml
   upstream_prod_database: <prod_db>
-  upstream_prod_schema: <prod_schema>
-  # Optional
-  upstream_prod_enabled: True  # Set as False to disable the package
-  upstream_prod_disabled_targets:  # List of targets where upstream_prod should be disabled
+  upstream_prod_fallack: True
+  upstream_prod_disabled_targets:
     - ci
     - prod
 ```
 
+### 3. Update `ref()`
 Next, you need to tell dbt to use this package's version of `{{ ref() }}` instead of the builtin macro. The recommended approach is to create a thin wrapper around `upstream-prod`. In your `macros` directory, create a file called `ref.sql` with the following contents:
 ```python
 {% macro ref(
@@ -53,10 +68,11 @@ Next, you need to tell dbt to use this package's version of `{{ ref() }}` instea
     current_model=this.name, 
     prod_database=var("upstream_prod_database", None), 
     prod_schema=var("upstream_prod_schema", None),
-    enabled=var("upstream_prod_enabled", True)
+    enabled=var("upstream_prod_enabled", True),
+    fallback=var("upstream_prod_fallback", False)
 ) %}
 
-  {% do return(upstream_prod.ref(parent_model, current_model, prod_database, prod_schema, enabled)) %}
+  {% do return(upstream_prod.ref(parent_model, current_model, prod_database, prod_schema, enabled, fallback)) %}
 
 {% endmacro %}
 ```
@@ -64,4 +80,4 @@ Next, you need to tell dbt to use this package's version of `{{ ref() }}` instea
 Alternatively, you can find any instances of `{{ ref() }}` in your project and replace them with `{{ upstream_prod.ref() }}`
 
 ## Compatibility
-`upstream-prod` has been designed and tested on Snowflake only. It _should_ work with other officially supported adapted but I can't be sure. If it doesn't, PRs are welcome!
+`upstream-prod` has been designed and tested on Snowflake only. It _should_ work with other officially supported adapters but I can't be sure. If it doesn't, PRs are welcome!

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Next, you need to tell dbt to use this package's version of `{{ ref() }}` instea
 {% macro ref(
     parent_model, 
     current_model=this.name, 
-    prod_database=var("upstream_prod_database"), 
-    prod_schema=var("upstream_prod_schema"),
+    prod_database=var("upstream_prod_database", None), 
+    prod_schema=var("upstream_prod_schema", None),
     enabled=var("upstream_prod_enabled", True)
 ) %}
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'upstream_prod'
-version: '0.1.1'
+version: '0.2.0'
 config-version: 2
 
 require-dbt-version: [">=1.1.0", "<2.0.0"]

--- a/macros/ref.sql
+++ b/macros/ref.sql
@@ -1,8 +1,8 @@
 {% macro ref(
     parent_model, 
     current_model=this.name, 
-    prod_database=var("upstream_prod_database"), 
-    prod_schema=var("upstream_prod_schema"),
+    prod_database=var("upstream_prod_database", None), 
+    prod_schema=var("upstream_prod_schema", None),
     enabled=var("upstream_prod_enabled", True)
 ) %}
     {{ return(adapter.dispatch("ref", "upstream_prod")(parent_model, current_model, prod_database, prod_schema, enabled)) }}
@@ -17,25 +17,32 @@
         {{ return(parent_ref) }}
     {% endif %}
 
+    {# Raise error if neither the upstream database or schema are set #}
+    {% if prod_database is none and prod_schema is none %}
+        {% set error_msg -%}
+upstream_prod is enabled but at least one required variable is missing.
+Please set at least one of the following variables to correctly configure the package:
+- upstream_prod_database
+- upstream_prod_schema
+
+The package can be disabled by setting the variable upstream_prod_enabled = False.
+        {%- endset %}
+        {% do exceptions.raise_compiler_error(error_msg) %}
+    {% endif %}
+
     {# List models selected for current run #}
     {% set selected_models = [] %}
     {% for model in selected_resources %}
-        {% if model.startswith("model.") %}
+        {% if model.startswith("model.") or model.startswith("snapshot.") %}
             {% do selected_models.append(model.split(".")[-1]) %}
         {% endif %}
     {% endfor %}
 
-    {# Defer to prod for upstream models if they haven't been selected for the current run #}
+    {# Defer to prod for upstream models not selected for the current run #}
     {% if current_model in selected_models and parent_model not in selected_models %}
-        {# Account for warehouse-specific terms: https://docs.getdbt.com/reference/dbt-jinja-functions/target #}
-        {% set target_database = target.database or target.dbname or target.project %}
-
-        {% set parent_database = parent_ref.database | replace(target_database, prod_database) %}
-        {% set parent_schema = parent_ref.schema | replace(target.schema, prod_schema) %}
-        
         {% set parent_ref = adapter.get_relation(
-                database=parent_database,
-                schema=parent_schema,
+                database=prod_database or parent_ref.database,
+                schema=prod_schema or parent_ref.schema,
                 identifier=parent_ref.identifier
         ) %}
     {% endif %}

--- a/macros/ref.sql
+++ b/macros/ref.sql
@@ -54,7 +54,12 @@ The package can be disabled by setting the variable upstream_prod_enabled = Fals
         {% if parent_model in selected_models %}
             {{ return(parent_ref) }}
         {% else %}
-            {% set parent_schema = parent_ref.schema | replace(target.schema, prod_schema) %}
+            {# Use parent ref schema when upstream schema is not set #}
+            {% if prod_schema is none %}
+                {% set parent_schema = parent_ref.schema %}
+            {% else %}
+                {% set parent_schema = parent_ref.schema | replace(target.schema, prod_schema) %}
+            {% endif %}
             {% set prod_ref = adapter.get_relation(
                     database=prod_database or parent_ref.database,
                     schema=parent_schema,

--- a/macros/ref.sql
+++ b/macros/ref.sql
@@ -44,9 +44,10 @@ The package can be disabled by setting the variable upstream_prod_enabled = Fals
         {% if parent_model in selected_models %}
             {{ return(parent_ref) }}
         {% else %}
+            {% set parent_schema = parent_ref.schema | replace(target.schema, prod_schema) %}
             {% set prod_ref = adapter.get_relation(
                     database=prod_database or parent_ref.database,
-                    schema=prod_schema or parent_ref.schema,
+                    schema=parent_schema,
                     identifier=parent_model
             ) %}
 


### PR DESCRIPTION
The variables `upstream_prod_database` and `upstream_prod_schema` tell the package where to find production data. Previously, both had to be set to avoid errors. Now only one is required, which should make it easier to use the package with certain setups.

There's now also an option to fall back to the default target when a relation doesn't exist in prod. This is useful when building  brand >1 new model. Instead of running all upstream models every time, e.g. `dbt run -s new_model_1 new_model_2`, you can use `dbt run -s new_model_2` and it will refer to the dev version of `new_model_1`.