### PR TITLE
Removing logging call sending many `True` and `False` messages to `stdout` and `stderr`

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'upstream_prod'
-version: '0.2.0'
+version: '0.2.1'
 config-version: 2
 
 require-dbt-version: [">=1.1.0", "<2.0.0"]

--- a/macros/ref.sql
+++ b/macros/ref.sql
@@ -22,7 +22,6 @@
     {% if execute %}
         {% set nodes = graph.nodes.values() %}
         {% set current_node = (nodes | selectattr("alias", "equalto", current_model) | list).pop() %}
-        {{ log(current_node.resource_type == 'test', info=True) }}
         {% if current_node.resource_type == 'test' %}
             {{ return(parent_ref) }}
         {% endif %}


### PR DESCRIPTION
Removed line from `ref.sql` that was, if I understand correctly, sending a boolean value to the `stdout` and `stderr` for each item returned from `graph.nodes.values()`. The boolean indicated if the node's `resource_type` was equal to `test`.

Per the discussion in [the issue here](https://github.com/LewisDavies/upstream-prod/issues/2) this was used for testing and included accidentally by @LewisDavies. 

Also changed version to `0.2.1`,