### PR TITLE
Improve handling of refs in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It is inspired by (but unrelated to) [similar work by Monzo](https://monzo.com/b
 ## How it works
 When developing locally, I would often get errors because my dev database had outdated or missing data. Rebuilding the models was often time-consuming and it wasn't easy to tell how many layers deep I needed to go.
 
-`upstream-prod` fixes this by overriding the `{{ ref() }}` macro, redirecting `ref`s in selected models to their equivalent table in production (unless the parent model was also selected).
+`upstream-prod` fixes this by overriding the `{{ ref() }}` macro, redirecting `ref`s in selected models & tests to their equivalent relations in your production environment.
 
 For example, imagine a simple DAG like:
 ```
@@ -25,8 +25,10 @@ jaffle_shop:
 ```
 If I run `dbt build -s model_2+`, the following happens:
 - `model_2` is built in `dev` with data from the `prod` version of `model_1`.
-- `model_3` is also built in my `dev` but it refers to the `dev` version of `model_2`.
+- `model_3` is also built in `dev` but it refers to the `dev` version of `model_2`.
 - Tests are run against the `dev` versions of `model_2` and `model_3`.
+
+> For tests that refer to multipe tables, such as relationship tests, the `prod` version of the comparison model will be used when available.
 
 In short, your selected models are available in your `dev` environment with all that lovely `prod` quality!
 
@@ -92,4 +94,4 @@ Next, you need to tell dbt to use this package's version of `{{ ref() }}` instea
 Alternatively, you can find any instances of `{{ ref() }}` in your project and replace them with `{{ upstream_prod.ref() }}`.
 
 ## Compatibility
-`upstream-prod` has been designed and tested on Snowflake only. It _should_ work with other officially supported adapters but I can't be sure. If it doesn't, PRs are welcome!
+`upstream-prod` has been designed and tested on Snowflake. User reports indicate that it works perfectly with BigQuery and Redshift, and it should also work with most community-supported adapters - PRs are welcome if it doesn't!

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'upstream_prod'
-version: '0.3.0'
+version: '0.4.0'
 config-version: 2
 
 require-dbt-version: [">=1.1.0", "<2.0.0"]

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -15,17 +15,17 @@ These instructions are intended to be used with Snowflake. They should work with
     ```sh
     # Using dev schemas
     dbt run -s stg__dev_fallback --vars 'upstream_prod_schema: prod' --target dev
-    dbt build -s dev_fallback --vars 'upstream_prod_schema: prod' --target dev
-    dbt run -s stg__defer_prod--vars 'upstream_prod_schema: prod' --target prod
+    dbt build -s dev_fallback --vars '{upstream_prod_schema: prod, upstream_prod_fallback: true}' --target dev
+    dbt run -s stg__defer_prod --vars 'upstream_prod_schema: prod' --target prod
     dbt build -s defer_prod --vars 'upstream_prod_schema: prod' --target dev
     # Using dev env schemas
     dbt run -s stg__dev_fallback --vars '{upstream_prod_schema: prod, upstream_prod_env_schemas: true}' --target dev
-    dbt build -s dev_fallback --vars '{upstream_prod_schema: prod, upstream_prod_env_schemas: true}' --target dev
+    dbt build -s dev_fallback --vars '{upstream_prod_schema: prod, upstream_prod_fallback: true, upstream_prod_env_schemas: true}' --target dev
     dbt run -s stg__defer_prod --vars '{upstream_prod_schema: prod, upstream_prod_env_schemas: true}' --target prod
     dbt build -s defer_prod --vars '{upstream_prod_schema: prod, upstream_prod_env_schemas: true}' --target dev
     # Using dev databases
     dbt run -s stg__dev_fallback --vars 'upstream_prod_database: upstream_prod__prod_db' --target dev_db
-    dbt build -s dev_fallback --vars 'upstream_prod_database: upstream_prod__prod_db' --target dev_db
+    dbt build -s dev_fallback --vars '{upstream_prod_database: upstream_prod__prod_db, upstream_prod_fallback: true}' --target dev_db
     dbt run -s stg__defer_prod --vars 'upstream_prod_database: upstream_prod__prod_db' --target prod_db
     dbt build -s defer_prod --vars 'upstream_prod_database: upstream_prod__prod_db' --target dev_db
     ```

--- a/integration_tests/models/final/_final_models.yml
+++ b/integration_tests/models/final/_final_models.yml
@@ -3,6 +3,11 @@ version: 2
 models:
   - name: defer_prod
     columns:
+      - name: id
+        tests:
+          - relationships:
+              to: ref('stg__defer_prod')
+              field: id
       - name: env
         tests:
           - accepted_values:
@@ -10,6 +15,11 @@ models:
 
   - name: dev_fallback
     columns:
+      - name: id
+        tests:
+          - relationships:
+              to: ref('stg__dev_fallback')
+              field: id
       - name: env
         tests:
           - accepted_values:

--- a/integration_tests/models/final/defer_prod.sql
+++ b/integration_tests/models/final/defer_prod.sql
@@ -1,1 +1,1 @@
-select env from {{ ref('stg__defer_prod') }}
+select id, env from {{ ref('stg__defer_prod') }}

--- a/integration_tests/models/final/dev_fallback.sql
+++ b/integration_tests/models/final/dev_fallback.sql
@@ -1,1 +1,1 @@
-select env from {{ ref('stg__dev_fallback', fallback=True) }}
+select id, env from {{ ref('stg__dev_fallback') }}

--- a/integration_tests/models/stg/stg__defer_prod.sql
+++ b/integration_tests/models/stg/stg__defer_prod.sql
@@ -1,1 +1,1 @@
-select 'prod' as env
+select 1 as id, 'prod' as env

--- a/integration_tests/models/stg/stg__dev_fallback.sql
+++ b/integration_tests/models/stg/stg__dev_fallback.sql
@@ -1,1 +1,1 @@
-select 'dev' as env
+select 1 as id, 'dev' as env

--- a/macros/ref.sql
+++ b/macros/ref.sql
@@ -11,25 +11,14 @@
 {% endmacro %}
 
 {% macro default__ref(parent_model, current_model, prod_database, prod_schema, enabled, fallback, env_schemas) %}
-
     {% set parent_ref = builtins.ref(parent_model) %}
 
-    {# Return builtin ref during parsing or when disabled #}
+    -- Return builtin ref during parsing or when disabled
     {% if not execute or target.name in var("upstream_prod_disabled_targets", []) or not enabled %}
         {{ return(parent_ref) }}
     {% endif %}
 
-    {# Return builtin ref for tests #}
-    {% if execute %}
-        {% set current_node = (graph.nodes.values()
-            | selectattr("alias", "equalto", current_model) 
-            | list).pop() %}
-        {% if current_node.resource_type == 'test' %}
-            {{ return(parent_ref) }}
-        {% endif %}
-    {% endif %}
-
-    {# Raise error if neither the upstream database or schema are set #}
+    -- Raise error if at least one required variable is not set
     {% if prod_database is none and prod_schema is none and not env_schemas %}
         {% set error_msg -%}
 upstream_prod is enabled but at least one required variable is missing.
@@ -43,46 +32,84 @@ The package can be disabled by setting the variable upstream_prod_enabled = Fals
         {% do exceptions.raise_compiler_error(error_msg) %}
     {% endif %}
 
-    {# List models selected for current run #}
-    {% set selected_models = [] %}
+    /*******************
+    Note on selection & tests
+
+    The selected_resources variable is a list of all nodes to be executed on the current run.
+    Below are some example elements:
+    1. model.my_project.my_model
+    2. snapshot.my_project.my_snapshot
+    3. test.unique_my_model_id.<hash>
+
+    In a nutshell, when ref() is called this package checks if the model is included in this 
+    list and returns the appropriate relation. However, running a test (e.g. dbt test -s my_model) 
+    only adds the test name (i.e. element 3) to selected_resources. The graph variable is used 
+    to identify the models relied on by each test.
+
+    Some tests rely on multiple models, such as relationship tests. For these, the package returns
+    the dev relation for explicity selected models and tries to fetch prod relations for comparison
+    models.
+    
+    Example: my_model has a relationship test against my_stg_model and dbt test -s my_model is run.
+    As my_model was explicitly selected by the user, the dev relation is used as the base and is
+    compared to the prod version of my_stg_model.
+    /*******************/
+    -- Find models & snapshots selected for current run
+    {% set selected = [] %}
+    {% set selected_tests = [] %}
     {% for res in selected_resources %}
-        {% if res.startswith("model.") or res.startswith("snapshot.") %}
-            {% do selected_models.append(res.split(".")[-1]) %}
+        {% if not res.startswith("test.") %}
+            {% do selected.append(res.split(".")[2]) %}
+        {% else %}
+            {% do selected_tests.append(res) %}
         {% endif %}
     {% endfor %}
 
-    {# Defer to prod for upstream models not selected for this run #}
-    {% if current_model in selected_models %}
-        {% if parent_model in selected_models %}
+    -- Find models being tested
+    {% for test in selected_tests %}
+        {% set tested_model = graph.nodes[test].file_key_name.split(".")[1] %}
+        -- Return dev relation for explicitly selected models
+        {% if parent_model == tested_model %}
+            {{ return(parent_ref) }}
+        -- Add other refs to selected for processing
+        {% else %}
+            {% do selected.append(parent_model) %}
+        {% endif %}
+    {% endfor %}
+
+    -- Use dev relations for models being built during the current run
+    {% if parent_model in selected %}
+        {{ return(parent_ref) }}
+    -- Defer to prod for non-selected upstream models
+    {% else %}
+        -- When using env schemas, use the graph to find the schema name that would be used in production environments
+        {% if env_schemas %}
+            {% set parent_node = graph.nodes.values() 
+                | selectattr("name", "equalto", parent_model)
+                | first %}
+            {% set parent_schema = parent_node.config.schema or prod_schema %}
+        -- No prod_schema value means a one-DB-per-developer setup, so assume schema names are consistent across
+        -- environments and use the schema name from the default parent ref
+        {% elif prod_schema is none %}
+            {% set parent_schema = parent_ref.schema %}
+        -- Reaching here means each developer has a separate set of schemas with different prefixes, which can
+        -- be identified with a simple find-and-replace
+        {% else %}
+            {% set parent_schema = parent_ref.schema | replace(target.schema, prod_schema) %}
+        {% endif %}
+
+        {% set prod_ref = adapter.get_relation(
+                database=prod_database or parent_ref.database,
+                schema=parent_schema,
+                identifier=parent_model
+        ) %}
+        -- If prod relation doesn't exist and fallback is enabled, return a ref to dev relation instead.
+        -- The dev relation may also not exist if the parent model hasn't been selected on the current run.
+        {% if prod_ref is none and fallback %}
+            {{ log("[" ~ current_model ~ "] " ~ parent_model ~ " not found in prod, falling back to default target", info=True) }}
             {{ return(parent_ref) }}
         {% else %}
-            {# Use parent ref schema when upstream schema is not set #}
-            {% if env_schemas %}
-                {% if execute %}
-                    {% set parent_node = (graph.nodes.values() 
-                        | selectattr("name", "equalto", parent_model)
-                        | list).pop() %}
-                    {% set parent_schema = parent_node.config.schema or prod_schema %}
-                {% endif %}
-            {% elif prod_schema is none %}
-                {% set parent_schema = parent_ref.schema %}
-            {% else %}
-                {% set parent_schema = parent_ref.schema | replace(target.schema, prod_schema) %}
-            {% endif %}
-            
-            {% set prod_ref = adapter.get_relation(
-                    database=prod_database or parent_ref.database,
-                    schema=parent_schema,
-                    identifier=parent_model
-            ) %}
-
-            {% if prod_ref is none and fallback %}
-                {{ log("[" ~ current_model ~ "] " ~ parent_model ~ " not found in prod, falling back to default target", info=True) }}
-                {{ return(parent_ref) }}
-            {% else %}
-                {{ return(prod_ref) }}
-            {% endif %}
+            {{ return(prod_ref) }}
         {% endif %}
     {% endif %}
-
 {% endmacro %}

--- a/macros/ref.sql
+++ b/macros/ref.sql
@@ -71,9 +71,6 @@ The package can be disabled by setting the variable upstream_prod_enabled = Fals
         -- Return dev relation for explicitly selected models
         {% if parent_model == tested_model %}
             {{ return(parent_ref) }}
-        -- Add other refs to selected for processing
-        {% else %}
-            {% do selected.append(parent_model) %}
         {% endif %}
     {% endfor %}
 


### PR DESCRIPTION
Previously, the package only looked for prod relations for models and snapshots. Most tests only have one ref, so getting refs with dbt's builtin macro was good enough. 

However, this wasn't ideal for tests with refs to multiple models, such as relationship tests; if a comparison model didn't exist in dev, tests would fail. These changes expands the model logic to cover tests.

- [ ] Update README with info on how test refs work
- [ ] Update package version