### PR TITLE
Add option to use most recently created / updated model

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ When using env schemas, you also need to add the `is_upstream_prod` parameter to
 - `upstream_prod_enabled`: Disables the package when False. Defaults to True.
 - `upstream_prod_disabled_targets`: List of targets where the package should be disabled.
 - `upstream_prod_fallback`: Whether to fall back to the default target when a model can't be found in prod. Defaults to False.
+- `upstream_prod_prefer_recent`: Whether to use dev relations that were updated more recently than prod; particularly useful when working on multiple large / slow models at once. Defaults to False.
 
 **Example**
 
@@ -88,6 +89,7 @@ I use Snowflake and each developer has a separate database with identically-name
 vars:
   upstream_prod_database: <prod_db> # replace with your prod db
   upstream_prod_fallback: True
+  upstream_prod_prefer_recent: True
   upstream_prod_disabled_targets:
     - ci
     - prod
@@ -112,10 +114,11 @@ In your `macros` directory, create a file called `ref.sql` with the following co
     enabled=var("upstream_prod_enabled", True),
     fallback=var("upstream_prod_fallback", False),
     env_schemas=var("upstream_prod_env_schemas", False),
-    version=None
+    version=None,
+    prefer_recent=var("upstream_prod_prefer_recent", False)
 ) %}
 
-  {% do return(upstream_prod.ref(parent_model, prod_database, prod_schema, enabled, fallback, env_schemas, version)) %}
+  {% do return(upstream_prod.ref(parent_model, prod_database, prod_schema, enabled, fallback, env_schemas, version, prefer_recent)) %}
 
 {% endmacro %}
 ```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ When using env schemas, you also need to add the `is_upstream_prod` parameter to
 - `upstream_prod_enabled`: Disables the package when False. Defaults to True.
 - `upstream_prod_disabled_targets`: List of targets where the package should be disabled.
 - `upstream_prod_fallback`: Whether to fall back to the default target when a model can't be found in prod. Defaults to False.
-- `upstream_prod_prefer_recent`: Whether to use dev relations that were updated more recently than prod; particularly useful when working on multiple large / slow models at once. Defaults to False.
+- `upstream_prod_prefer_recent`: Whether to use dev relations that were updated more recently than prod; particularly useful when working on multiple large / slow models at once. Only supported in Snowflake & BigQuery. Defaults to False.
 
 **Example**
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'upstream_prod'
-version: '0.6.2'
+version: '0.7.0'
 config-version: 2
 
 require-dbt-version: [">=1.5.0", "<2.0.0"]

--- a/integration_tests/_template/macros/ref.sql
+++ b/integration_tests/_template/macros/ref.sql
@@ -5,7 +5,8 @@
     enabled=var("upstream_prod_enabled", True),
     fallback=var("upstream_prod_fallback", False),
     env_schemas=var("upstream_prod_env_schemas", False),
-    version=None
+    version=None,
+    prefer_recent=var("upstream_prod_prefer_recent", False)
 ) %}
 
     {% do return(upstream_prod.ref(parent_model, prod_database, prod_schema, enabled, fallback, env_schemas, version)) %}

--- a/integration_tests/_template/models/production/dev_newer.sql
+++ b/integration_tests/_template/models/production/dev_newer.sql
@@ -1,0 +1,11 @@
+select
+    source_target,
+    source_database,
+    source_schema,
+    source_model,
+    '{{ target.name }}' as this_target,
+    '{{ this.database }}' as this_database,
+    '{{ this.schema }}' as this_schema,
+    '{{ this.name }}' as this_model
+from
+    {{ ref('stg__dev_newer') }}

--- a/integration_tests/_template/models/staging/stg__dev_newer.sql
+++ b/integration_tests/_template/models/staging/stg__dev_newer.sql
@@ -1,0 +1,6 @@
+select 
+    '{{ target.name }}' as source_target,
+    '{{ this.database }}' as source_database,
+    '{{ this.schema }}' as source_schema,
+    '{{ this.name }}' as source_model
+    

--- a/integration_tests/_template/models/staging/stg__dev_newer.sql
+++ b/integration_tests/_template/models/staging/stg__dev_newer.sql
@@ -3,4 +3,3 @@ select
     '{{ this.database }}' as source_database,
     '{{ this.schema }}' as source_schema,
     '{{ this.name }}' as source_model
-    

--- a/integration_tests/_template/run_tests.sh
+++ b/integration_tests/_template/run_tests.sh
@@ -8,8 +8,8 @@ dbt run-operation create_test_db --args '{db: upstream__dev_db}'
 
 # Create staging model in appropriate envs
 echo "\nBUILDING STAGING MODELS\n"
-dbt build -s stg__defer_prod stg__defer_vers --target prod
-dbt build -s stg__dev_fallback
+dbt build -s stg__defer_prod stg__defer_vers stg__dev_newer --target prod
+dbt build -s stg__dev_fallback stg__dev_newer
 
 # Build & test downstream models
 echo "\nBUILDING DOWNSTREAM MODELS\n"

--- a/integration_tests/dev_db/dbt_project.yml
+++ b/integration_tests/dev_db/dbt_project.yml
@@ -22,3 +22,4 @@ models:
 vars:
   upstream_prod_database: upstream__prod_db
   upstream_prod_fallback: true
+  upstream_prod_prefer_recent: true

--- a/integration_tests/dev_db/macros/ref.sql
+++ b/integration_tests/dev_db/macros/ref.sql
@@ -5,7 +5,8 @@
     enabled=var("upstream_prod_enabled", True),
     fallback=var("upstream_prod_fallback", False),
     env_schemas=var("upstream_prod_env_schemas", False),
-    version=None
+    version=None,
+    prefer_recent=var("upstream_prod_prefer_recent", False)
 ) %}
 
     {% do return(upstream_prod.ref(parent_model, prod_database, prod_schema, enabled, fallback, env_schemas, version)) %}

--- a/integration_tests/dev_db/models/production/_dev_db_models.yml
+++ b/integration_tests/dev_db/models/production/_dev_db_models.yml
@@ -161,6 +161,44 @@ models:
               values: ['dev_fallback']
 
 
+  - name: dev_newer
+    columns:
+      # Source
+      - name: source_target
+        tests:
+          - accepted_values:
+              values: ['dev']
+      - name: source_database
+        tests:
+          - accepted_values:
+              values: ['upstream__dev_db']
+      - name: source_schema
+        tests:
+          - accepted_values:
+              values: ['prod_stg']
+      - name: source_model
+        tests:
+          - accepted_values:
+              values: ['stg__dev_newer']
+      # This
+      - name: this_target
+        tests:
+          - accepted_values:
+              values: ['dev']
+      - name: this_database
+        tests:
+          - accepted_values:
+              values: ['upstream__dev_db']
+      - name: this_schema
+        tests:
+          - accepted_values:
+              values: ['prod']
+      - name: this_model
+        tests:
+          - accepted_values:
+              values: ['dev_newer']
+
+
   - name: ephem
     columns:
       # Source

--- a/integration_tests/dev_db/models/production/dev_newer.sql
+++ b/integration_tests/dev_db/models/production/dev_newer.sql
@@ -1,0 +1,11 @@
+select
+    source_target,
+    source_database,
+    source_schema,
+    source_model,
+    '{{ target.name }}' as this_target,
+    '{{ this.database }}' as this_database,
+    '{{ this.schema }}' as this_schema,
+    '{{ this.name }}' as this_model
+from
+    {{ ref('stg__dev_newer') }}

--- a/integration_tests/dev_db/models/staging/stg__dev_newer.sql
+++ b/integration_tests/dev_db/models/staging/stg__dev_newer.sql
@@ -1,0 +1,6 @@
+select 
+    '{{ target.name }}' as source_target,
+    '{{ this.database }}' as source_database,
+    '{{ this.schema }}' as source_schema,
+    '{{ this.name }}' as source_model
+    

--- a/integration_tests/dev_db/models/staging/stg__dev_newer.sql
+++ b/integration_tests/dev_db/models/staging/stg__dev_newer.sql
@@ -3,4 +3,3 @@ select
     '{{ this.database }}' as source_database,
     '{{ this.schema }}' as source_schema,
     '{{ this.name }}' as source_model
-    

--- a/integration_tests/dev_db/run_tests.sh
+++ b/integration_tests/dev_db/run_tests.sh
@@ -8,8 +8,8 @@ dbt run-operation create_test_db --args '{db: upstream__dev_db}'
 
 # Create staging model in appropriate envs
 echo "\nBUILDING STAGING MODELS\n"
-dbt build -s stg__defer_prod stg__defer_vers --target prod
-dbt build -s stg__dev_fallback
+dbt build -s stg__defer_prod stg__defer_vers stg__dev_newer --target prod
+dbt build -s stg__dev_fallback stg__dev_newer
 
 # Build & test downstream models
 echo "\nBUILDING DOWNSTREAM MODELS\n"

--- a/integration_tests/dev_db_dev_sch/dbt_project.yml
+++ b/integration_tests/dev_db_dev_sch/dbt_project.yml
@@ -23,3 +23,4 @@ vars:
   upstream_prod_database: upstream__prod_db
   upstream_prod_schema: prod
   upstream_prod_fallback: true
+  upstream_prod_prefer_recent: true

--- a/integration_tests/dev_db_dev_sch/macros/ref.sql
+++ b/integration_tests/dev_db_dev_sch/macros/ref.sql
@@ -5,7 +5,8 @@
     enabled=var("upstream_prod_enabled", True),
     fallback=var("upstream_prod_fallback", False),
     env_schemas=var("upstream_prod_env_schemas", False),
-    version=None
+    version=None,
+    prefer_recent=var("upstream_prod_prefer_recent", False)
 ) %}
 
     {% do return(upstream_prod.ref(parent_model, prod_database, prod_schema, enabled, fallback, env_schemas, version)) %}

--- a/integration_tests/dev_db_dev_sch/models/production/_dev_db_dev_sch_models.yml
+++ b/integration_tests/dev_db_dev_sch/models/production/_dev_db_dev_sch_models.yml
@@ -161,6 +161,44 @@ models:
               values: ['dev_fallback']
 
 
+  - name: dev_newer
+    columns:
+      # Source
+      - name: source_target
+        tests:
+          - accepted_values:
+              values: ['dev']
+      - name: source_database
+        tests:
+          - accepted_values:
+              values: ['upstream__dev_db']
+      - name: source_schema
+        tests:
+          - accepted_values:
+              values: ['dev_stg']
+      - name: source_model
+        tests:
+          - accepted_values:
+              values: ['stg__dev_newer']
+      # This
+      - name: this_target
+        tests:
+          - accepted_values:
+              values: ['dev']
+      - name: this_database
+        tests:
+          - accepted_values:
+              values: ['upstream__dev_db']
+      - name: this_schema
+        tests:
+          - accepted_values:
+              values: ['dev']
+      - name: this_model
+        tests:
+          - accepted_values:
+              values: ['dev_newer']
+
+
   - name: ephem
     columns:
       # Source

--- a/integration_tests/dev_db_dev_sch/models/production/dev_newer.sql
+++ b/integration_tests/dev_db_dev_sch/models/production/dev_newer.sql
@@ -1,0 +1,11 @@
+select
+    source_target,
+    source_database,
+    source_schema,
+    source_model,
+    '{{ target.name }}' as this_target,
+    '{{ this.database }}' as this_database,
+    '{{ this.schema }}' as this_schema,
+    '{{ this.name }}' as this_model
+from
+    {{ ref('stg__dev_newer') }}

--- a/integration_tests/dev_db_dev_sch/models/staging/stg__dev_newer.sql
+++ b/integration_tests/dev_db_dev_sch/models/staging/stg__dev_newer.sql
@@ -1,0 +1,6 @@
+select 
+    '{{ target.name }}' as source_target,
+    '{{ this.database }}' as source_database,
+    '{{ this.schema }}' as source_schema,
+    '{{ this.name }}' as source_model
+    

--- a/integration_tests/dev_db_dev_sch/models/staging/stg__dev_newer.sql
+++ b/integration_tests/dev_db_dev_sch/models/staging/stg__dev_newer.sql
@@ -3,4 +3,3 @@ select
     '{{ this.database }}' as source_database,
     '{{ this.schema }}' as source_schema,
     '{{ this.name }}' as source_model
-    

--- a/integration_tests/dev_db_dev_sch/run_tests.sh
+++ b/integration_tests/dev_db_dev_sch/run_tests.sh
@@ -8,8 +8,8 @@ dbt run-operation create_test_db --args '{db: upstream__dev_db}'
 
 # Create staging model in appropriate envs
 echo "\nBUILDING STAGING MODELS\n"
-dbt build -s stg__defer_prod stg__defer_vers --target prod
-dbt build -s stg__dev_fallback
+dbt build -s stg__defer_prod stg__defer_vers stg__dev_newer --target prod
+dbt build -s stg__dev_fallback stg__dev_newer
 
 # Build & test downstream models
 echo "\nBUILDING DOWNSTREAM MODELS\n"

--- a/integration_tests/dev_db_env_sch/dbt_project.yml
+++ b/integration_tests/dev_db_env_sch/dbt_project.yml
@@ -23,3 +23,4 @@ vars:
   upstream_prod_database: upstream__prod_db
   upstream_prod_fallback: true
   upstream_prod_env_schemas: true
+  upstream_prod_prefer_recent: true

--- a/integration_tests/dev_db_env_sch/macros/ref.sql
+++ b/integration_tests/dev_db_env_sch/macros/ref.sql
@@ -5,7 +5,8 @@
     enabled=var("upstream_prod_enabled", True),
     fallback=var("upstream_prod_fallback", False),
     env_schemas=var("upstream_prod_env_schemas", False),
-    version=None
+    version=None,
+    prefer_recent=var("upstream_prod_prefer_recent", False)
 ) %}
 
     {% do return(upstream_prod.ref(parent_model, prod_database, prod_schema, enabled, fallback, env_schemas, version)) %}

--- a/integration_tests/dev_db_env_sch/models/production/_dev_db_env_sch_models.yml
+++ b/integration_tests/dev_db_env_sch/models/production/_dev_db_env_sch_models.yml
@@ -161,6 +161,44 @@ models:
               values: ['dev_fallback']
 
 
+  - name: dev_newer
+    columns:
+      # Source
+      - name: source_target
+        tests:
+          - accepted_values:
+              values: ['dev']
+      - name: source_database
+        tests:
+          - accepted_values:
+              values: ['upstream__dev_db']
+      - name: source_schema
+        tests:
+          - accepted_values:
+              values: ['dev']
+      - name: source_model
+        tests:
+          - accepted_values:
+              values: ['stg__dev_newer']
+      # This
+      - name: this_target
+        tests:
+          - accepted_values:
+              values: ['dev']
+      - name: this_database
+        tests:
+          - accepted_values:
+              values: ['upstream__dev_db']
+      - name: this_schema
+        tests:
+          - accepted_values:
+              values: ['dev']
+      - name: this_model
+        tests:
+          - accepted_values:
+              values: ['dev_newer']
+
+
   - name: ephem
     columns:
       # Source

--- a/integration_tests/dev_db_env_sch/models/production/dev_newer.sql
+++ b/integration_tests/dev_db_env_sch/models/production/dev_newer.sql
@@ -1,0 +1,11 @@
+select
+    source_target,
+    source_database,
+    source_schema,
+    source_model,
+    '{{ target.name }}' as this_target,
+    '{{ this.database }}' as this_database,
+    '{{ this.schema }}' as this_schema,
+    '{{ this.name }}' as this_model
+from
+    {{ ref('stg__dev_newer') }}

--- a/integration_tests/dev_db_env_sch/models/staging/stg__dev_newer.sql
+++ b/integration_tests/dev_db_env_sch/models/staging/stg__dev_newer.sql
@@ -1,0 +1,6 @@
+select 
+    '{{ target.name }}' as source_target,
+    '{{ this.database }}' as source_database,
+    '{{ this.schema }}' as source_schema,
+    '{{ this.name }}' as source_model
+    

--- a/integration_tests/dev_db_env_sch/models/staging/stg__dev_newer.sql
+++ b/integration_tests/dev_db_env_sch/models/staging/stg__dev_newer.sql
@@ -3,4 +3,3 @@ select
     '{{ this.database }}' as source_database,
     '{{ this.schema }}' as source_schema,
     '{{ this.name }}' as source_model
-    

--- a/integration_tests/dev_db_env_sch/run_tests.sh
+++ b/integration_tests/dev_db_env_sch/run_tests.sh
@@ -8,8 +8,8 @@ dbt run-operation create_test_db --args '{db: upstream__dev_db}'
 
 # Create staging model in appropriate envs
 echo "\nBUILDING STAGING MODELS\n"
-dbt build -s stg__defer_prod stg__defer_vers --target prod
-dbt build -s stg__dev_fallback
+dbt build -s stg__defer_prod stg__defer_vers stg__dev_newer --target prod
+dbt build -s stg__dev_fallback stg__dev_newer
 
 # Build & test downstream models
 echo "\nBUILDING DOWNSTREAM MODELS\n"

--- a/integration_tests/dev_sch/dbt_project.yml
+++ b/integration_tests/dev_sch/dbt_project.yml
@@ -22,3 +22,4 @@ models:
 vars:
   upstream_prod_schema: prod  
   upstream_prod_fallback: true
+  upstream_prod_prefer_recent: true

--- a/integration_tests/dev_sch/macros/ref.sql
+++ b/integration_tests/dev_sch/macros/ref.sql
@@ -5,7 +5,8 @@
     enabled=var("upstream_prod_enabled", True),
     fallback=var("upstream_prod_fallback", False),
     env_schemas=var("upstream_prod_env_schemas", False),
-    version=None
+    version=None,
+    prefer_recent=var("upstream_prod_prefer_recent", False)
 ) %}
 
     {% do return(upstream_prod.ref(parent_model, prod_database, prod_schema, enabled, fallback, env_schemas, version)) %}

--- a/integration_tests/dev_sch/models/production/_dev_sch_models.yml
+++ b/integration_tests/dev_sch/models/production/_dev_sch_models.yml
@@ -161,6 +161,44 @@ models:
               values: ['dev_fallback']
 
 
+  - name: dev_newer
+    columns:
+      # Source
+      - name: source_target
+        tests:
+          - accepted_values:
+              values: ['dev']
+      - name: source_database
+        tests:
+          - accepted_values:
+              values: ['upstream__prod_db']
+      - name: source_schema
+        tests:
+          - accepted_values:
+              values: ['dev_stg']
+      - name: source_model
+        tests:
+          - accepted_values:
+              values: ['stg__dev_newer']
+      # This
+      - name: this_target
+        tests:
+          - accepted_values:
+              values: ['dev']
+      - name: this_database
+        tests:
+          - accepted_values:
+              values: ['upstream__prod_db']
+      - name: this_schema
+        tests:
+          - accepted_values:
+              values: ['dev']
+      - name: this_model
+        tests:
+          - accepted_values:
+              values: ['dev_newer']
+
+
   - name: ephem
     columns:
       # Source

--- a/integration_tests/dev_sch/models/production/dev_newer.sql
+++ b/integration_tests/dev_sch/models/production/dev_newer.sql
@@ -1,0 +1,11 @@
+select
+    source_target,
+    source_database,
+    source_schema,
+    source_model,
+    '{{ target.name }}' as this_target,
+    '{{ this.database }}' as this_database,
+    '{{ this.schema }}' as this_schema,
+    '{{ this.name }}' as this_model
+from
+    {{ ref('stg__dev_newer') }}

--- a/integration_tests/dev_sch/models/staging/stg__dev_newer.sql
+++ b/integration_tests/dev_sch/models/staging/stg__dev_newer.sql
@@ -1,0 +1,6 @@
+select 
+    '{{ target.name }}' as source_target,
+    '{{ this.database }}' as source_database,
+    '{{ this.schema }}' as source_schema,
+    '{{ this.name }}' as source_model
+    

--- a/integration_tests/dev_sch/models/staging/stg__dev_newer.sql
+++ b/integration_tests/dev_sch/models/staging/stg__dev_newer.sql
@@ -3,4 +3,3 @@ select
     '{{ this.database }}' as source_database,
     '{{ this.schema }}' as source_schema,
     '{{ this.name }}' as source_model
-    

--- a/integration_tests/dev_sch/run_tests.sh
+++ b/integration_tests/dev_sch/run_tests.sh
@@ -8,8 +8,8 @@ dbt run-operation create_test_db --args '{db: upstream__dev_db}'
 
 # Create staging model in appropriate envs
 echo "\nBUILDING STAGING MODELS\n"
-dbt build -s stg__defer_prod stg__defer_vers --target prod
-dbt build -s stg__dev_fallback
+dbt build -s stg__defer_prod stg__defer_vers stg__dev_newer --target prod
+dbt build -s stg__dev_fallback stg__dev_newer
 
 # Build & test downstream models
 echo "\nBUILDING DOWNSTREAM MODELS\n"

--- a/integration_tests/env_sch/dbt_project.yml
+++ b/integration_tests/env_sch/dbt_project.yml
@@ -22,3 +22,4 @@ models:
 vars:
   upstream_prod_fallback: true
   upstream_prod_env_schemas: true
+  upstream_prod_prefer_recent: true

--- a/integration_tests/env_sch/macros/ref.sql
+++ b/integration_tests/env_sch/macros/ref.sql
@@ -5,7 +5,8 @@
     enabled=var("upstream_prod_enabled", True),
     fallback=var("upstream_prod_fallback", False),
     env_schemas=var("upstream_prod_env_schemas", False),
-    version=None
+    version=None,
+    prefer_recent=var("upstream_prod_prefer_recent", False)
 ) %}
 
     {% do return(upstream_prod.ref(parent_model, prod_database, prod_schema, enabled, fallback, env_schemas, version)) %}

--- a/integration_tests/env_sch/models/production/_env_sch_models.yml
+++ b/integration_tests/env_sch/models/production/_env_sch_models.yml
@@ -161,6 +161,44 @@ models:
               values: ['dev_fallback']
 
 
+  - name: dev_newer
+    columns:
+      # Source
+      - name: source_target
+        tests:
+          - accepted_values:
+              values: ['dev']
+      - name: source_database
+        tests:
+          - accepted_values:
+              values: ['upstream__prod_db']
+      - name: source_schema
+        tests:
+          - accepted_values:
+              values: ['dev']
+      - name: source_model
+        tests:
+          - accepted_values:
+              values: ['stg__dev_newer']
+      # This
+      - name: this_target
+        tests:
+          - accepted_values:
+              values: ['dev']
+      - name: this_database
+        tests:
+          - accepted_values:
+              values: ['upstream__prod_db']
+      - name: this_schema
+        tests:
+          - accepted_values:
+              values: ['dev']
+      - name: this_model
+        tests:
+          - accepted_values:
+              values: ['dev_newer']
+
+
   - name: ephem
     columns:
       # Source

--- a/integration_tests/env_sch/models/production/dev_newer.sql
+++ b/integration_tests/env_sch/models/production/dev_newer.sql
@@ -1,0 +1,11 @@
+select
+    source_target,
+    source_database,
+    source_schema,
+    source_model,
+    '{{ target.name }}' as this_target,
+    '{{ this.database }}' as this_database,
+    '{{ this.schema }}' as this_schema,
+    '{{ this.name }}' as this_model
+from
+    {{ ref('stg__dev_newer') }}

--- a/integration_tests/env_sch/models/staging/stg__dev_newer.sql
+++ b/integration_tests/env_sch/models/staging/stg__dev_newer.sql
@@ -1,0 +1,6 @@
+select 
+    '{{ target.name }}' as source_target,
+    '{{ this.database }}' as source_database,
+    '{{ this.schema }}' as source_schema,
+    '{{ this.name }}' as source_model
+    

--- a/integration_tests/env_sch/models/staging/stg__dev_newer.sql
+++ b/integration_tests/env_sch/models/staging/stg__dev_newer.sql
@@ -3,4 +3,3 @@ select
     '{{ this.database }}' as source_database,
     '{{ this.schema }}' as source_schema,
     '{{ this.name }}' as source_model
-    

--- a/integration_tests/env_sch/run_tests.sh
+++ b/integration_tests/env_sch/run_tests.sh
@@ -8,8 +8,8 @@ dbt run-operation create_test_db --args '{db: upstream__dev_db}'
 
 # Create staging model in appropriate envs
 echo "\nBUILDING STAGING MODELS\n"
-dbt build -s stg__defer_prod stg__defer_vers --target prod
-dbt build -s stg__dev_fallback
+dbt build -s stg__defer_prod stg__defer_vers stg__dev_newer --target prod
+dbt build -s stg__dev_fallback stg__dev_newer
 
 # Build & test downstream models
 echo "\nBUILDING DOWNSTREAM MODELS\n"

--- a/macros/check_reqd_vars.sql
+++ b/macros/check_reqd_vars.sql
@@ -1,0 +1,24 @@
+{% macro check_reqd_vars(prod_database, prod_schema, env_schemas) %}
+    {{ return(adapter.dispatch("check_reqd_vars", "upstream_prod")(prod_database, prod_schema, env_schemas)) }}
+{% endmacro %}
+
+{% macro default__check_reqd_vars(prod_database, prod_schema, env_schemas) %}
+
+    {% 
+        if prod_database is none 
+        and prod_schema is none 
+        and env_schemas == false
+    %}
+        {% set error_msg -%}
+upstream_prod is enabled but at least one required variable is missing.
+Please set at least one of the following variables to correctly configure the package:
+- upstream_prod_database
+- upstream_prod_schema
+- upstream_prod_env_schemas
+
+The package can be disabled by setting the variable upstream_prod_enabled = False.
+        {%- endset %}
+        {% do exceptions.raise_compiler_error(error_msg) %}
+    {% endif %}
+
+{% endmacro %}

--- a/macros/find_model_node.sql
+++ b/macros/find_model_node.sql
@@ -1,0 +1,23 @@
+{% macro find_model_node(model, version) %}
+    {{ return(adapter.dispatch("find_model_node", "upstream_prod")(model, version)) }}
+{% endmacro %}
+
+{% macro default__find_model_node(model, version) %}
+
+    {% if execute %}
+        {% set matching_nodes = [] %}
+        {% for n in graph.nodes.values() if n["name"] == model %}
+            {% if version is not none %}
+                {% if n["version"] == version %}
+                    {% do matching_nodes.append(n) %}
+                {% endif %}
+            {% else %}
+                {% if n["version"] == n["latest_version"] %}
+                    {% do matching_nodes.append(n) %}
+                {% endif %}
+            {% endif %}
+        {% endfor %}
+        {{ return(matching_nodes | first) }}
+    {% endif %}
+
+{% endmacro %}

--- a/macros/find_selected_nodes.sql
+++ b/macros/find_selected_nodes.sql
@@ -1,0 +1,50 @@
+{% macro find_selected_nodes(parent_model) %}
+    {{ return(adapter.dispatch("find_selected_nodes", "upstream_prod")(parent_model)) }}
+{% endmacro %}
+
+{% macro default__find_selected_nodes(parent_model) %}
+    /*******************
+    Note on selection & tests
+
+    The selected_resources variable is a list of all nodes to be executed on the current run.
+    Below are some example elements:
+    1. model.my_project.my_model
+    2. snapshot.my_project.my_snapshot
+    3. test.unique_my_model_id.<hash>
+
+    In a nutshell, when ref() is called this package checks if the model is included in this 
+    list and returns the appropriate relation. However, running a test (e.g. dbt test -s my_model) 
+    only adds the test name (i.e. element 3) to selected_resources. The graph variable is used 
+    to identify the models relied on by each test.
+
+    Some tests rely on multiple models, such as relationship tests. For these, the package returns
+    the dev relation for explicity selected models and tries to fetch prod relations for comparison
+    models.
+    
+    Example: my_model has a relationship test against my_stg_model and dbt test -s my_model is run.
+    As my_model was explicitly selected by the user, the dev relation is used as the base and is
+    compared to the prod version of my_stg_model.
+    /*******************/
+
+    -- Find models & snapshots selected for current run
+    {% set selected = [] %}
+    {% set selected_tests = [] %}
+    {% for res in selected_resources %}
+        {% if not res.startswith("test.") %}
+            {% do selected.append(res.split(".")[2]) %}
+        {% else %}
+            {% do selected_tests.append(res) %}
+        {% endif %}
+    {% endfor %}
+
+    -- Find models being tested
+    {% for test in selected_tests %}
+        {% set tested_model = graph.nodes[test].file_key_name.split(".")[1] %}
+        {% if parent_model == tested_model %}
+            {% do selected.append(parent_model) %}
+        {% endif %}
+    {% endfor %}
+
+    {{ return(selected) }}
+
+{% endmacro %}

--- a/macros/find_selected_nodes.sql
+++ b/macros/find_selected_nodes.sql
@@ -39,10 +39,12 @@
 
     -- Find models being tested
     {% for test in selected_tests %}
-        {% set tested_model = graph.nodes[test].file_key_name.split(".")[1] %}
-        {% if parent_model == tested_model %}
-            {% do selected.append(parent_model) %}
-        {% endif %}
+        {% set test_node = graph.nodes[test] %}
+        {% for test_ref in test_node.refs %}
+            {% if parent_model == test_ref.name %}
+                {% do selected.append(parent_model) %}
+            {% endif %}
+        {% endfor %}
     {% endfor %}
 
     {{ return(selected) }}

--- a/macros/get_table_update_ts.sql
+++ b/macros/get_table_update_ts.sql
@@ -1,0 +1,64 @@
+{% macro get_table_update_ts(relation) %}
+    {{ return(adapter.dispatch("get_table_update_ts", "upstream_prod")(relation)) }}
+{% endmacro %}
+
+{% macro snowflake__get_table_update_ts(relation) %}
+
+    {% set table_info_query %}
+        select
+            last_altered 
+        from
+            {{ relation.database }}.information_schema.tables
+        where
+            table_catalog = upper('{{ relation.database }}')
+            and table_schema = upper('{{ relation.schema }}')
+            and table_name = upper('{{ relation.identifier }}')
+    {% endset %}
+
+    {% set result = run_query(table_info_query) %}
+    {% if result | length == 0 %}
+        {{ return(None) }}
+    {% elif result | length > 1 %}
+        {% set error_msg %}
+Multiple matches in information schema for {{ relation }}
+        {% endset %}
+        {% do exceptions.raise_compiler_error(error_msg) %}
+    {% else %}
+        {{ return(result.rows.values()[0][0] ) }}
+    {% endif %}
+    
+{% endmacro %}
+
+{% macro bigquery__get_table_update_ts(relation) %}
+
+    {% set table_info_query %}
+        select
+            coalesce(
+                timestamp_millis(meta.last_modified_time), 
+                inf_sch.creation_time
+            ) as last_altered
+        from
+            {{ relation.database }}.{{ relation.schema }}.INFORMATION_SCHEMA.TABLES inf_sch
+            left join {{ relation.database }}.{{ relation.schema }}.__TABLES__ meta
+                on inf_sch.table_catalog = meta.project_id
+                and inf_sch.table_schema = meta.dataset_id
+                and inf_sch.table_name = meta.table_id
+        where
+            inf_sch.table_catalog = '{{ relation.database }}'
+            and inf_sch.table_schema = '{{ relation.schema }}'
+            and inf_sch.table_name = '{{ relation.identifier }}'
+    {% endset %}
+
+    {% set result = run_query(table_info_query) %}
+    {% if result | length == 0 %}
+        {{ return(None) }}
+    {% elif result | length > 1 %}
+        {% set error_msg %}
+Multiple matches in information schema for {{ relation }}
+        {% endset %}
+        {% do exceptions.raise_compiler_error(error_msg) %}
+    {% else %}
+        {{ return(result.rows.values()[0][0] ) }}
+    {% endif %}
+    
+{% endmacro %}

--- a/macros/raise_ref_not_found_error.sql
+++ b/macros/raise_ref_not_found_error.sql
@@ -1,0 +1,19 @@
+{% macro raise_ref_not_found_error(current_model, relation) %}
+    {{ return(adapter.dispatch("raise_ref_not_found_error", "upstream_prod")(current_model, relation)) }}
+{% endmacro %}
+
+{% macro default__raise_ref_not_found_error(current_model, relation) %}
+
+    {% set error_msg -%}
+[{{ current_model }}] upstream_prod couldnt find the specified model:
+
+DATABASE: {{ relation.database }}
+SCHEMA:   {{ realtion.schema }}
+RELATION: {{ relation.identifier }}
+
+Check your variable settings in the README or create a GitHub issue for more help.
+    {%- endset %}
+
+    {% do exceptions.raise_compiler_error(error_msg) %}
+
+{% endmacro %}

--- a/macros/ref.sql
+++ b/macros/ref.sql
@@ -5,148 +5,75 @@
     enabled=var("upstream_prod_enabled", True),
     fallback=var("upstream_prod_fallback", False),
     env_schemas=var("upstream_prod_env_schemas", False),
-    version=None
+    version=None,
+    prefer_recent=var("upstream_prod_prefer_recent", False)
 ) %}
-    {{ return(adapter.dispatch("ref", "upstream_prod")(parent_model, prod_database, prod_schema, enabled, fallback, env_schemas, version)) }}
+    {{ return(adapter.dispatch("ref", "upstream_prod")(parent_model, prod_database, prod_schema, enabled, fallback, env_schemas, version, prefer_recent)) }}
 {% endmacro %}
 
-{% macro default__ref(parent_model, prod_database, prod_schema, enabled, fallback, env_schemas, version) %}
+{% macro default__ref(parent_model, prod_database, prod_schema, enabled, fallback, env_schemas, version, prefer_recent) %}
     {% set parent_ref = builtins.ref(parent_model, version=version) %}
     {% set current_model = this.name if this is defined else 'unknown model' %}
 
-    -- Return builtin ref during parsing or when disabled
-    {% 
-        if execute == false
-        or enabled == false
-        or target.name in var("upstream_prod_disabled_targets", []) 
-    %}
+    -- Return builtin ref for ephemeral models, during parsing or when disabled
+    {% if execute == false or enabled == false or parent_ref.is_cte
+        or target.name in var("upstream_prod_disabled_targets", []) %}
         {{ return(parent_ref) }}
     {% endif %}
 
     -- Raise error if at least one required variable is not set
-    {% 
-        if prod_database is none 
-        and prod_schema is none 
-        and env_schemas == false
-    %}
-        {% set error_msg -%}
-upstream_prod is enabled but at least one required variable is missing.
-Please set at least one of the following variables to correctly configure the package:
-- upstream_prod_database
-- upstream_prod_schema
-- upstream_prod_env_schemas
+    {{ upstream_prod.check_reqd_vars(prod_database, prod_schema, env_schemas) }}
 
-The package can be disabled by setting the variable upstream_prod_enabled = False.
-        {%- endset %}
-        {% do exceptions.raise_compiler_error(error_msg) %}
-    {% endif %}
-
-    /*******************
-    Note on selection & tests
-
-    The selected_resources variable is a list of all nodes to be executed on the current run.
-    Below are some example elements:
-    1. model.my_project.my_model
-    2. snapshot.my_project.my_snapshot
-    3. test.unique_my_model_id.<hash>
-
-    In a nutshell, when ref() is called this package checks if the model is included in this 
-    list and returns the appropriate relation. However, running a test (e.g. dbt test -s my_model) 
-    only adds the test name (i.e. element 3) to selected_resources. The graph variable is used 
-    to identify the models relied on by each test.
-
-    Some tests rely on multiple models, such as relationship tests. For these, the package returns
-    the dev relation for explicity selected models and tries to fetch prod relations for comparison
-    models.
-    
-    Example: my_model has a relationship test against my_stg_model and dbt test -s my_model is run.
-    As my_model was explicitly selected by the user, the dev relation is used as the base and is
-    compared to the prod version of my_stg_model.
-    /*******************/
-
-    -- Find models & snapshots selected for current run
-    {% set selected = [] %}
-    {% set selected_tests = [] %}
-    {% for res in selected_resources %}
-        {% if not res.startswith("test.") %}
-            {% do selected.append(res.split(".")[2]) %}
-        {% else %}
-            {% do selected_tests.append(res) %}
-        {% endif %}
-    {% endfor %}
-
-    -- Find models being tested
-    {% for test in selected_tests %}
-        {% set test_node = graph.nodes[test] %}
-        {% for test_ref in test_node.refs %}
-            -- Return dev relation for explicitly selected models
-            {% if parent_model == test_ref.name %}
-                {{ return(parent_ref) }}
-            {% endif %}
-        {% endfor %}
-    {% endfor %}
-
+    {% set selected = upstream_prod.find_selected_nodes(parent_model) %}
     -- Use dev relations for models being built during the current run
     {% if parent_model in selected %}
         {{ return(parent_ref) }}
     -- Try deferring to prod for non-selected upstream models
     {% else %}
-        -- Find parent node, accounting for (un)specified model version
-        {% set matching_nodes = [] %}
-        {% for n in graph.nodes.values() if n["name"] == parent_model %}
-            {% if version is not none %}
-                {% if n["version"] == version %}
-                    {% do matching_nodes.append(n) %}
-                {% endif %}
-            {% else %}
-                {% if n["version"] == n["latest_version"] %}
-                    {% do matching_nodes.append(n) %}
-                {% endif %}
-            {% endif %}
-        {% endfor %}
-        {% set parent_node = matching_nodes | first %}
-
-        -- Use builtin ref for ephemeral models
-        {% if parent_node.config.materialized == "ephemeral" %}
-            {{ return(parent_ref) }}
-        -- When using env schemas, use the graph to find the schema name that would be used in production environments
-        {% elif env_schemas == true %}
+        {% if env_schemas == true %}
+            {% set parent_node = upstream_prod.find_model_node(parent_model, version) %}
             {% set custom_schema_name = parent_node.config.schema %}
             {% set parent_schema = generate_schema_name(custom_schema_name, parent_node, True) | trim %}
-        -- No prod_schema value means a one-DB-per-developer setup, so assume schema names are consistent across
-        -- environments and use the schema name from the default parent ref
+        -- No prod_schema = one-DB-per-env setup with same schema structure in all
         {% elif prod_schema is none %}
             {% set parent_schema = parent_ref.schema %}
-        -- Reaching here means each developer has a separate set of schemas with different prefixes, which can
-        -- be identified with a simple find-and-replace
+        -- Schema structure is <env>[_<level>], e.g. prod, prod_stg or dev_int 
         {% else %}
             {% set parent_schema = parent_ref.schema | replace(target.schema, prod_schema) %}
         {% endif %}
-
-        -- Build final ref and check that it exists
         {% set parent_database = prod_database or parent_ref.database %}
-        {% set return_ref = adapter.get_relation(parent_database, parent_schema, parent_ref.table) %}
 
-        -- If prod relation doesn't exist and fallback is enabled, try the dev relation instead.
-        {% if return_ref is none and fallback == true %}
-            {{ log("[" ~ current_model ~ "] " ~ parent_ref.table ~ " not found in prod, falling back to default target", info=True) }}
-            {% set return_ref = load_relation(parent_ref) %}
-        {% endif %}
+        {% set prod_rel = adapter.get_relation(parent_database, parent_schema, parent_ref.table) %}
+        {% set dev_rel = load_relation(parent_ref) %}
+        {% set prod_exists = prod_rel is not none %}
+        {% set dev_exists = dev_rel is not none %}
 
-        -- Return final ref, or raise error if relation isn't found
-        {% if return_ref is not none %}
-            {{ return(return_ref) }}
+        {% if prod_exists %}
+            -- When option enabled, return the mostly recently updated of dev & prod relations
+            {% if prefer_recent and dev_exists %}
+                -- Find when dev & prod relations were last updated
+                {% set dev_updated = upstream_prod.get_table_update_ts(dev_rel) %}
+                {% set prod_updated = upstream_prod.get_table_update_ts(prod_rel) %}
+
+                {% if dev_updated > prod_updated %}
+                    {{ log("[" ~ current_model ~ "] " ~ parent_ref.table ~ " fresher in dev than prod, switching to dev relation", info=True) }}
+                    {{ return(dev_rel) }}
+                {% else %}
+                    {{ return(prod_rel) }}
+                {% endif %}
+            {% else %}
+                {{ return(prod_rel) }}
+            {% endif %}
+        {% elif dev_exists %}
+            -- Return dev relation if prod doesn't exist & option is enabled
+            {% if fallback %}
+                {{ log("[" ~ current_model ~ "] " ~ parent_ref.table ~ " not found in prod, falling back to default target", info=True) }}
+                {{ return(dev_rel) }}
+            {% else %}
+                {{ upstream_prod.raise_ref_not_found_error(current_model, dev_rel) }}
+            {% endif %}
         {% else %}
-            {% set error_msg -%}
-[{{ current_model }}] upstream_prod couldn't find the specified model:
-
-DATABASE: {{ parent_database }}
-SCHEMA:   {{ parent_schema }}
-RELATION: {{ parent_ref.table }}
-
-Check your variable settings in the README or create a GitHub issue for more help.
-            {%- endset %}
-            {% do exceptions.raise_compiler_error(error_msg) %}
+            {{ upstream_prod.raise_ref_not_found_error(current_model, prod_rel) }}
         {% endif %}
 
     {% endif %}


### PR DESCRIPTION
The package can now use a dev model if it was created or updated later the prod version.

The first iteration only supports Snowflake & BigQuery. Support for other platforms will depend on user contributions.