### PR TITLE
Add default macro

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'upstream_prod'
-version: '0.7.1'
+version: '0.7.2'
 config-version: 2
 
 require-dbt-version: [">=1.5.0", "<2.0.0"]

--- a/macros/get_table_update_ts.sql
+++ b/macros/get_table_update_ts.sql
@@ -2,6 +2,10 @@
     {{ return(adapter.dispatch("get_table_update_ts", "upstream_prod")(relation)) }}
 {% endmacro %}
 
+{% macro default__get_table_update_ts(relation) %}
+    -- This is intentionally blank to avoid an error on non-compatible databases
+{% endmacro %}
+
 {% macro snowflake__get_table_update_ts(relation) %}
 
     {% set table_info_query %}


### PR DESCRIPTION
Fixes an error when using databases that don't have an appropriate way of finding a relation's last update timestamp.