### PR TITLE
Improve compatibiltiy with custom model aliases

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'upstream_prod'
-version: '0.7.2'
+version: '0.7.3'
 config-version: 2
 
 require-dbt-version: [">=1.5.0", "<2.0.0"]

--- a/macros/raise_ref_not_found_error.sql
+++ b/macros/raise_ref_not_found_error.sql
@@ -1,15 +1,15 @@
-{% macro raise_ref_not_found_error(current_model, relation) %}
-    {{ return(adapter.dispatch("raise_ref_not_found_error", "upstream_prod")(current_model, relation)) }}
+{% macro raise_ref_not_found_error(current_model, database, schema, relation) %}
+    {{ return(adapter.dispatch("raise_ref_not_found_error", "upstream_prod")(current_model, database, schema, relation)) }}
 {% endmacro %}
 
-{% macro default__raise_ref_not_found_error(current_model, relation) %}
+{% macro default__raise_ref_not_found_error(current_model, database, schema, relation) %}
 
     {% set error_msg -%}
 [{{ current_model }}] upstream_prod couldnt find the specified model:
 
-DATABASE: {{ relation.database }}
-SCHEMA:   {{ relation.schema }}
-RELATION: {{ relation.identifier }}
+DATABASE: {{ database }}
+SCHEMA:   {{ schema }}
+RELATION: {{ relation }}
 
 Check your variable settings in the README or create a GitHub issue for more help.
     {%- endset %}


### PR DESCRIPTION
Adds support for projects using a custom `generate_alias_name` macro.

I have assumed that custom aliases are only used in dev environments and prod relations always have the same name as the model (+ version suffix when needed). The approach is a little hacky but it seems to work - and if prod relations differ from model file names, you're probably trying to use dbt in hacky way anyway.

This is only a minor version bump as there should be no difference to projects that don't use custom aliases.