### PR TITLE
Use macro to get last update timestamp

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,12 +1,12 @@
-name: 'upstream_prod'
-version: '0.9.0'
+name: "upstream_prod"
+version: "0.9.1"
 config-version: 2
 
 require-dbt-version: [">=1.5.0", "<2.0.0"]
 
 macro-paths: ["macros"]
 
-target-path: "target"  # directory which will store compiled SQL files
-clean-targets:         # directories to be removed by `dbt clean`
+target-path: "target" # directory which will store compiled SQL files
+clean-targets: # directories to be removed by `dbt clean`
   - "target"
   - "dbt_packages"

--- a/macros/get_table_update_ts.sql
+++ b/macros/get_table_update_ts.sql
@@ -42,16 +42,6 @@ upstream_prod_prefer_recent is set to true but this feature is incompatible with
         {{ return(None) }}
     {% endif %}
 
-    {% set result = run_query(table_info_query) %}
-    {% if result | length == 0 %}
-        {{ return(None) }}
-    {% elif result | length > 1 %}
-        {% set error_msg %}
-Multiple matches in information schema for {{ relation }}
-        {% endset %}
-        {% do exceptions.raise_compiler_error(error_msg) %}
-    {% else %}
-        {{ return(result.rows.values()[0][0] ) }}
-    {% endif %}
+    {{ return(dbt_utils.get_single_value(table_info_query, None)) }}
 
 {% endmacro %}


### PR DESCRIPTION
## Background

The dictionary-based method of fetching the result of the last update query was causing an error with dbt Fusion. This is fixed by using the `dbt_utils.get_single_value` macro.

## Checklist

- [x] Checked `ref` parameters are consistent across the primary macro, test projects & README
- [x] Added tests if necessary
- [x] Passed integration tests
- [x] Checked installation instructions
- [x] Bumped package version
