### PR TITLE
Improve dbt Fusion compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Your custom schema macro needs two small tweaks to work with the package. As an 
     {%- set default_schema = target.schema -%}
     -- 2. In the clause that generates your prod schema names, add a check that the value is True
     --    **Make sure to enclose the or condition in brackets**
-    {%- if (target.name == "prod" or is_upstream_prod == true) and custom_schema_name is not none -%}
+    {%- if (target.name == "prod" or is_upstream_prod is true) and custom_schema_name is not none -%}
 
         {{ custom_schema_name | trim }}
 
@@ -118,7 +118,7 @@ Your custom schema macro needs two small tweaks to work with the package. As an 
     {%- set default_schema = target.schema -%}
     -- 2. In the clause that generates your prod schema names, add a check that the value is True
     --    **Make sure to enclose the or condition in brackets**
-    {%- if (target.name == "prod" or is_upstream_prod == true) and custom_schema_name is not none -%}
+    {%- if (target.name == "prod" or is_upstream_prod is true) and custom_schema_name is not none -%}
 
         {{ custom_schema_name | trim }}
 
@@ -167,7 +167,7 @@ Then update your custom database macro in exactly the same way as your schema ma
     {%- set default_database = target.database -%}
     -- 2. In the clause that generates your prod database names, add a check that the value is True
     --    **Make sure to enclose the or condition in brackets**
-    {%- if (target.name == "prod" or is_upstream_prod == true) and custom_database_name is not none -%}
+    {%- if (target.name == "prod" or is_upstream_prod is true) and custom_database_name is not none -%}
 
         {{ custom_database_name | trim }}
 
@@ -222,7 +222,7 @@ Your custom database macro now needs two small tweaks to work with the package, 
     {%- set default_database = target.database -%}
     -- 2. In the clause that generates your prod database names, add a check that the value is True
     --    **Make sure to enclose the or condition in brackets**
-    {%- if (target.name == "prod" or is_upstream_prod == true) and custom_database_name is not none -%}
+    {%- if (target.name == "prod" or is_upstream_prod is true) and custom_database_name is not none -%}
 
         {{ custom_database_name | trim }}
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: "upstream_prod"
-version: "0.9.1"
+version: "0.9.2"
 config-version: 2
 
 require-dbt-version: [">=1.5.0", "<2.0.0"]

--- a/integration_tests/dev_db_env_sch/macros/generate_custom_schema.sql
+++ b/integration_tests/dev_db_env_sch/macros/generate_custom_schema.sql
@@ -1,7 +1,7 @@
 {% macro generate_schema_name(custom_schema_name, node, is_upstream_prod=False) -%}
 
     {%- set default_schema = target.schema -%}
-    {%- if (target.name == "prod" or is_upstream_prod == true) and custom_schema_name is not none -%}
+    {%- if (target.name == "prod" or is_upstream_prod is true) and custom_schema_name is not none -%}
 
         {{ custom_schema_name | trim }}
 

--- a/integration_tests/env_db/macros/generate_custom_database.sql
+++ b/integration_tests/env_db/macros/generate_custom_database.sql
@@ -1,7 +1,7 @@
 {% macro generate_database_name(custom_database_name=none, node=none, is_upstream_prod=False) -%}
 
     {%- set default_database = target.database -%}
-    {%- if (target.name == "prod" or is_upstream_prod == true) and custom_database_name is not none -%}
+    {%- if (target.name == "prod" or is_upstream_prod is true) and custom_database_name is not none -%}
 
         {{ custom_database_name | trim }}
 

--- a/integration_tests/env_sch/macros/generate_custom_schema.sql
+++ b/integration_tests/env_sch/macros/generate_custom_schema.sql
@@ -1,7 +1,7 @@
 {% macro generate_schema_name(custom_schema_name, node, is_upstream_prod=False) -%}
 
     {%- set default_schema = target.schema -%}
-    {%- if (target.name == "prod" or is_upstream_prod == true) and custom_schema_name is not none -%}
+    {%- if (target.name == "prod" or is_upstream_prod is true) and custom_schema_name is not none -%}
 
         {{ custom_schema_name | trim }}
 

--- a/macros/check_reqd_vars.sql
+++ b/macros/check_reqd_vars.sql
@@ -8,8 +8,8 @@
     {% 
         if prod_database is none 
         and prod_schema is none 
-        and env_schemas == false
-        and env_dbs == false
+        and env_schemas is false
+        and env_dbs is false
     %}
         {% set error_msg -%}
 upstream_prod is enabled but at least one required variable is missing.
@@ -25,7 +25,7 @@ The package can be disabled by setting the variable upstream_prod_enabled = Fals
     {% endif %}
 
     -- The env_dbs option also needs the prod db name to work properly
-    {% if env_dbs == true and prod_database is none %}
+    {% if env_dbs is true and prod_database is none %}
         {% set error_msg -%}
 upstream_prod_env_dbs is set to true but the production database name was not provided.
 Please use the upstream_prod_database variable to set the database name.

--- a/macros/find_model_node.sql
+++ b/macros/find_model_node.sql
@@ -4,7 +4,7 @@
 
 {% macro default__find_model_node(model, project, version) %}
 
-    {% if execute == true %}
+    {% if execute is true %}
         {% set matching_nodes = [] %}
         {% for n in graph.nodes.values() if n["name"] == model %}
             {% if project is none or project == n["package_name"] %}

--- a/macros/ref.sql
+++ b/macros/ref.sql
@@ -55,7 +55,7 @@
     {% set current_model = this.name if this is defined else "unknown model" %}
 
     -- Return builtin ref for ephemeral models, during parsing or when disabled
-    {% if execute == false or enabled == false or parent_ref.is_cte
+    {% if execute is false or enabled is false or parent_ref.is_cte
         or target.name in var("upstream_prod_disabled_targets", []) %}
         {{ return(parent_ref) }}
     {% endif %}
@@ -75,7 +75,7 @@
         {% if parent_node.resource_type == "snapshot" %}
             -- Snapshots use the same schema name regardless of the environment
             {% set parent_schema = parent_node.schema %}
-        {% elif env_schemas == true %}
+        {% elif env_schemas is true %}
             -- Schema generated with custom macro
             {% set custom_schema_name = parent_node.config.schema %}
             {% set parent_schema = generate_schema_name(custom_schema_name, parent_node, True) | trim %}
@@ -88,7 +88,7 @@
         {% endif %}
 
         -- Set prod database name
-        {% if env_dbs == true %}
+        {% if env_dbs is true %}
             -- Database generated with custom macro
             {% set parent_database = generate_database_name(prod_database, parent_node, True) | trim %}
         {% else %}
@@ -113,9 +113,9 @@
         -- Default to returning the prod relation, but override in the circumstances outlined below
         {% set return_rel = prod_rel %}
 
-        {% if prod_exists == true %}
+        {% if prod_exists is true %}
             -- When option enabled, return the mostly recently updated of dev & prod relations
-            {% if prefer_recent == true and dev_exists == true %}
+            {% if prefer_recent is true and dev_exists is true %}
                 -- Find when dev & prod relations were last updated
                 {% set dev_updated = upstream_prod.get_table_update_ts(dev_rel) %}
                 {% set prod_updated = upstream_prod.get_table_update_ts(prod_rel) %}
@@ -128,7 +128,7 @@
             {% endif %}
         {% elif dev_exists %}
             -- Return dev relation if prod doesn't exist & fallback is enabled
-            {% if fallback == true %}
+            {% if fallback is true %}
                 {{ log("[" ~ current_model ~ "] " ~ parent_ref.table ~ " not found in prod, falling back to default target", info=True) }}
                 {% set return_rel = dev_rel %}
             {% else %}

--- a/macros/ref.sql
+++ b/macros/ref.sql
@@ -55,8 +55,12 @@
     {% set current_model = this.name if this is defined else "unknown model" %}
 
     -- Return builtin ref for ephemeral models, during parsing or when disabled
-    {% if execute is false or enabled is false or parent_ref.is_cte
-        or target.name in var("upstream_prod_disabled_targets", []) %}
+    {% if execute is false
+        or enabled is false
+        or parent_ref.is_cte
+        or target.name in var("upstream_prod_disabled_targets", [])
+        or flags.WHICH == "compile"
+    %}
         {{ return(parent_ref) }}
     {% endif %}
 


### PR DESCRIPTION
## Background

A [bug](https://github.com/dbt-labs/dbt-fusion/issues/514) in dbt Fusion means that `execute` is set to `{}` when it would have been `false` in Core. That means the `{% if execute == false ...` check [here](https://github.com/LewisDavies/upstream-prod/blob/cb301e8dcaf43eaeff84a7367ca907ade32c70ea/macros/ref.sql#L58) always returns `False`. Changing `==` to `is` means the [built-in Jinja test](https://jinja.palletsprojects.com/en/stable/templates/#jinja-tests.true) is used. Following these changes, when `execute` is set as `{}` the check gives the expected value of `True` instead.

However, even with this fix the behaviour is still different. When command is `dbt compile`, Fusion appears to trigger the [get_table_update_ts](https://github.com/LewisDavies/upstream-prod/blob/cb301e8dcaf43eaeff84a7367ca907ade32c70ea/macros/get_table_update_ts.sql) macro for every model in the project. This doesn't happen with Core. The additional check against `flags.WHICH` prevents these queries from running when we're only compiling the project. 

## Checklist

- [x] Checked `ref` parameters are consistent across the primary macro, test projects & README
- [x] Added tests if necessary
- [ ] Passed integration tests (not yet updated for Fusion)
- [x] Checked installation instructions
- [x] Bumped package version
