### PR TITLE
Backup route for cache misses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# upstream-prod
+
+A dbt package that overrides `ref()` to resolve references against production data in development environments.
+
+## Commands
+
+```bash
+make setup           # Create .venv and .env from .env.example
+make test            # Integration tests on all platforms
+make test-snowflake  # Single platform (also test-databricks, test-bigquery)
+```
+
+## Architecture
+
+All logic lives in `macros/`. The package works by overriding dbt's built-in `ref()` macro:
+
+| Macro | Purpose |
+|---|---|
+| `ref.sql` | Entry point — dispatches to `default__ref`, which decides whether to return a dev or prod relation |
+| `get_prod_relation.sql` | Resolves the prod database/schema/name for a given node |
+| `find_model_node.sql` | Looks up a node in `graph.nodes` by model name |
+| `find_selected_nodes.sql` | Returns the set of models selected in the current run |
+| `populate_cache.sql` | `on-run-start` hook — pre-fetches timestamps for all unselected parent nodes and stores them in `graph["_upstream_prod_cache"]` |
+| `query_table_last_altered.sql` | Adapter-dispatched SQL — queries `information_schema` for `last_altered` timestamps. Returns a raw result set. |
+| `get_node_timestamps.sql` | Calls `query_table_last_altered`, parses result rows into `{resource: {env: {database, schema, name, last_altered}}}` |
+| `add_node_to_check.sql` | Mutates a `to_check` dict in place to add dev and prod entries for a single node (shared between `populate_cache` and the `ref` slow path) |
+| `check_reqd_vars.sql` | Validates required variables are set |
+| `raise_ref_not_found_error.sql` | Raises a consistent error when a relation can't be found |
+
+### `prefer_recent` flow
+
+When `upstream_prod_prefer_recent: true` is set:
+
+1. `populate_cache` runs via `on-run-start`, querying timestamps for all unselected parent models and storing them in `graph["_upstream_prod_cache"]`.
+2. In `ref.sql`, if both dev and prod relations exist and the cache contains an entry for the parent, the cached timestamps determine which relation to return.
+3. **Cache miss** (e.g. `dbt compile`, dbt Power User preview, or stale cache from a long-running process): `ref.sql` falls back to a live `get_node_timestamps` call for just that one model pair.
+
+### Dispatch pattern
+
+All macros follow the same pattern — a thin public entry point that delegates to adapter-specific implementations:
+
+```jinja
+{% macro my_macro(args) %}
+    {{ return(adapter.dispatch("my_macro", "upstream_prod")(args)) }}
+{% endmacro %}
+
+{% macro default__my_macro(args) %}...{% endmacro %}
+{% macro snowflake__my_macro(args) %}...{% endmacro %}
+```
+
+## Integration Tests
+
+Tests live in `integration_tests/`. The test runner:
+1. Iterates over all project configs in `dbt_project_files/` (each tests a different schema/database setup)
+2. Sets `UP_TARGET_PLATFORM` (resolved to a profile in `integration_tests/profiles.yml`)
+3. Builds staging models in prod, then downstream models in dev, then asserts correct relation resolution
+
+`dbt_project_files/` configs tested: `dev_db`, `dev_db_dev_sch`, `dev_db_env_sch`, `dev_sch`, `env_dbs`, `env_sch`.
+
+## Environment
+
+Copy `.env.example` to `.env` and fill in credentials before running tests. Python deps managed with `uv` (`make setup`).

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 export
 export DBT_PROJECT_DIR=$(CURDIR)/integration_tests
 export DBT_PROFILES_DIR=$(CURDIR)/integration_tests
+export PYTHONWARNINGS=ignore
 
 .PHONY: setup test-snowflake test-databricks test-bigquery test debug-snowflake debug-databricks debug-bigquery debug
 
@@ -33,27 +34,13 @@ debug-bigquery:
 
 # Tests
 test:
-	@echo ""
-	@echo "========================================"
-	@echo "  Platform: Snowflake"
-	@echo "========================================"
-	@$(MAKE) test-snowflake
-	@echo ""
-	@echo "========================================"
-	@echo "  Platform: Databricks"
-	@echo "========================================"
-	@$(MAKE) test-databricks
-	@echo ""
-	@echo "========================================"
-	@echo "  Platform: BigQuery"
-	@echo "========================================"
-	@$(MAKE) test-bigquery
+	@DBT_QUIET=true sh integration_tests/run_tests.sh
 
 test-snowflake:
-	@UP_TARGET_PLATFORM=sf DBT_QUIET=true sh integration_tests/run_tests.sh
+	@DBT_QUIET=true sh integration_tests/run_tests.sh sf
 
 test-databricks:
-	@UP_TARGET_PLATFORM=dbx DBT_QUIET=true sh integration_tests/run_tests.sh
+	@DBT_QUIET=true sh integration_tests/run_tests.sh dbx
 
 test-bigquery:
-	@UP_TARGET_PLATFORM=bq DBT_QUIET=true sh integration_tests/run_tests.sh
+	@DBT_QUIET=true sh integration_tests/run_tests.sh bq

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: "upstream_prod"
-version: "0.10.0"
+version: "0.10.1"
 config-version: 2
 
 require-dbt-version: [">=1.5.0", "<3.0.0"]

--- a/integration_tests/run_tests.sh
+++ b/integration_tests/run_tests.sh
@@ -27,7 +27,7 @@ do
     echo "  Platform: $(platform_name $platform)"
     echo "========================================"
 
-    UP_TARGET_PLATFORM=$platform
+    export UP_TARGET_PLATFORM=$platform
 
     for file in dbt_project_files/*
     do

--- a/integration_tests/run_tests.sh
+++ b/integration_tests/run_tests.sh
@@ -4,35 +4,61 @@ set -e
 script_dir=$(dirname "$(readlink -f "$0")")
 cd $script_dir
 
-for file in dbt_project_files/*
+# Map platform codes to display names
+platform_name() {
+    case $1 in
+        sf)  echo "Snowflake" ;;
+        dbx) echo "Databricks" ;;
+        bq)  echo "BigQuery" ;;
+    esac
+}
+
+# Default to all platforms; allow a single platform as an argument
+if [ -n "$1" ]; then
+    platforms="$1"
+else
+    platforms="sf dbx bq"
+fi
+
+for platform in $platforms
 do
-    cp $file dbt_project.yml
-    project=$(basename $file .yml)
-    start=$SECONDS
-
     echo ""
-    echo "  Project: $project"
+    echo "========================================"
+    echo "  Platform: $(platform_name $platform)"
+    echo "========================================"
 
-    echo "    Setting up..."
-    dbt clean
-    dbt deps
-    dbt run-operation create_test_db --args '{db: upproddb}'
-    dbt run-operation create_test_db --args '{db: updevdb}'
+    UP_TARGET_PLATFORM=$platform
 
-    echo "    Running staging models..."
-    dbt snapshot -t prod
-    dbt run -s stg__defer_prod stg__defer_vers stg__dev_newer stg__cross_project stg__microbatch -t prod
-    dbt run -s stg__dev_fallback stg__dev_newer
+    for file in dbt_project_files/*
+    do
+        cp $file dbt_project.yml
+        project=$(basename $file .yml)
+        start=$SECONDS
 
-    echo "    Building downstream models..."
-    # event-time flags only affect the microbatch model
-    dbt build -s models/marts --event-time-start "2025-01-01" --event-time-end "2025-01-03"
+        echo ""
+        echo "  Project: $project"
 
-    echo "    Checking --empty flag..."
-    dbt build -s defer_prod --empty
+        echo "    Setting up..."
+        dbt clean
+        dbt deps
+        dbt run-operation create_test_db --args '{db: upproddb}'
+        dbt run-operation create_test_db --args '{db: updevdb}'
 
-    echo "    Checking codegen output..."
-    dbt run-operation generate_model_yaml --args '{"model_names": [stg__defer_prod]}' > /dev/null
+        echo "    Running staging models..."
+        dbt snapshot -t prod
+        dbt run -s stg__defer_prod stg__defer_vers stg__dev_newer stg__cross_project stg__microbatch -t prod
+        dbt run -s stg__dev_fallback stg__dev_newer
 
-    echo "  Done in $((SECONDS - start))s"
+        echo "    Building downstream models..."
+        # event-time flags only affect the microbatch model
+        dbt build -s models/marts --event-time-start "2025-01-01" --event-time-end "2025-01-03"
+
+        echo "    Checking --empty flag..."
+        dbt build -s defer_prod --empty
+
+        echo "    Checking codegen output..."
+        dbt run-operation generate_model_yaml --args '{"model_names": [stg__defer_prod]}' > /dev/null
+
+        echo "  Done in $((SECONDS - start))s"
+    done
 done

--- a/macros/add_node_to_check.sql
+++ b/macros/add_node_to_check.sql
@@ -1,0 +1,31 @@
+{% macro add_node_to_check(to_check, parent_node, prod_rel_db, prod_rel_schema, prod_rel_name, parent_resource, parent_name) %}
+    {{ return(adapter.dispatch("add_node_to_check", "upstream_prod")(to_check, parent_node, prod_rel_db, prod_rel_schema, prod_rel_name, parent_resource, parent_name)) }}
+{% endmacro %}
+
+{% macro default__add_node_to_check(to_check, parent_node, prod_rel_db, prod_rel_schema, prod_rel_name, parent_resource, parent_name) %}
+    {% set dev_db = parent_node["database"] %}
+    {% set dev_schema = parent_node["schema"] %}
+    {% if dev_db not in to_check %}
+        {% do to_check.update({dev_db: {}}) %}
+    {% endif %}
+    {% if dev_schema not in to_check[dev_db] %}
+        {% do to_check[dev_db].update({dev_schema: []}) %}
+    {% endif %}
+    {% do to_check[dev_db][dev_schema].append({
+        "resource": parent_resource,
+        "env": "dev",
+        "name": parent_name
+    }) %}
+
+    {% if prod_rel_db not in to_check %}
+        {% do to_check.update({prod_rel_db: {}}) %}
+    {% endif %}
+    {% if prod_rel_schema not in to_check[prod_rel_db] %}
+        {% do to_check[prod_rel_db].update({prod_rel_schema: []}) %}
+    {% endif %}
+    {% do to_check[prod_rel_db][prod_rel_schema].append({
+        "resource": parent_resource,
+        "env": "prod",
+        "name": prod_rel_name
+    }) %}
+{% endmacro %}

--- a/macros/get_node_timestamps.sql
+++ b/macros/get_node_timestamps.sql
@@ -1,0 +1,24 @@
+{% macro get_node_timestamps(to_check) %}
+    {{ return(adapter.dispatch("get_node_timestamps", "upstream_prod")(to_check)) }}
+{% endmacro %}
+
+{% macro default__get_node_timestamps(to_check) %}
+    {% set checked = upstream_prod.query_table_last_altered(to_check) %}
+    {% set output = {} %}
+    {% if checked is not none %}
+        {% for row in checked.data %}
+            {% if row[0] not in output %}
+                {% do output.update({row[0]: {}}) %}
+            {% endif %}
+            {% do output[row[0]].update({
+                row[1]: {
+                    "database": row[2],
+                    "schema": row[3],
+                    "name": row[4],
+                    "last_altered": row[5]
+                }
+            }) %}
+        {% endfor %}
+    {% endif %}
+    {{ return(output) }}
+{% endmacro %}

--- a/macros/populate_cache.sql
+++ b/macros/populate_cache.sql
@@ -23,35 +23,9 @@
                     {% set parent_node = graph.nodes[parent] %}
                     {% set parent_name = parent_node["alias"] or parent_node["name"] %}
                     {% set parent_resource = parent_node["package_name"] ~ "." ~ parent_name %}
-
-                    {# Add dev relation to check list, grouped by database and schema #}
-                    {% set dev_db = parent_node["database"] %}
-                    {% set dev_schema = parent_node["schema"] %}
-                    {% if dev_db not in to_check %}
-                        {% do to_check.update({dev_db: {}}) %}
-                    {% endif %}
-                    {% if dev_schema not in to_check[dev_db] %}
-                        {% do to_check[dev_db].update({dev_schema: []}) %}
-                    {% endif %}
-                    {% do to_check[dev_db][dev_schema].append({
-                        "resource": parent_resource,
-                        "env": "dev",
-                        "name": parent_name
-                    }) %}
-
-                    {# Find prod relation and add to check list #}
                     {% set prod_rel_db, prod_rel_schema, prod_rel_name = upstream_prod.get_prod_relation(parent_node, parent_node["database"], parent_node["schema"]) %}
-                    {% if prod_rel_db not in to_check %}
-                        {% do to_check.update({prod_rel_db: {}}) %}
-                    {% endif %}
-                    {% if prod_rel_schema not in to_check[prod_rel_db] %}
-                        {% do to_check[prod_rel_db].update({prod_rel_schema: []}) %}
-                    {% endif %}
-                    {% do to_check[prod_rel_db][prod_rel_schema].append({
-                        "resource": parent_resource,
-                        "env": "prod",
-                        "name": prod_rel_name
-                    }) %}
+
+                    {{ upstream_prod.add_node_to_check(to_check, parent_node, prod_rel_db, prod_rel_schema, prod_rel_name, parent_resource, parent_name) }}
                 {% endif %}
             {% endfor %}
         {% endfor %}
@@ -60,28 +34,8 @@
         the integration_tests snapshots which don't use ref or source, it's probably quite rare for
         this pattern to appear in real models. #}
         {% if to_check | length > 0 %}
-            {# Get timestamps of last update #}
-            {% set checked = upstream_prod.get_table_update_ts(to_check) %}
-
-            {% set output = {} %}
-            {% for row in checked.data %}
-                {# Add dict for each relation #}
-                {% if row[0] not in output %}
-                    {% do output.update({row[0]: {}}) %}
-                {% endif %}
-                {# Add sub-dict for dev and prod (if they exist) #}
-                {% do output[row[0]].update({
-                    row[1]: {
-                        "database": row[2],
-                        "schema": row[3],
-                        "name": row[4],
-                        "last_altered": row[5]
-                    }
-                }) %}
-            {% endfor %}
-
             {# Persist timestamps on the graph for the rest of the run #}
-            {% do graph.update({"_upstream_prod_cache": output}) %}
+            {% do graph.update({"_upstream_prod_cache": upstream_prod.get_node_timestamps(to_check)}) %}
         {% endif %}
 
     {% endif %}

--- a/macros/query_table_last_altered.sql
+++ b/macros/query_table_last_altered.sql
@@ -1,8 +1,8 @@
-{% macro get_table_update_ts(resources) %}
-    {{ return(adapter.dispatch("get_table_update_ts", "upstream_prod")(resources)) }}
+{% macro query_table_last_altered(resources) %}
+    {{ return(adapter.dispatch("query_table_last_altered", "upstream_prod")(resources)) }}
 {% endmacro %}
 
-{% macro default__get_table_update_ts(resources) %}
+{% macro default__query_table_last_altered(resources) %}
 
     {% set warning_msg %}
 upstream_prod_prefer_recent is set to true but this feature is incompatible with {{ target.type }} databases. Unsetting the variable may improve project performance.
@@ -14,7 +14,7 @@ upstream_prod_prefer_recent is set to true but this feature is incompatible with
 {% endmacro %}
 
 
-{% macro snowflake__get_table_update_ts(resources) %}
+{% macro snowflake__query_table_last_altered(resources) %}
     -- Query assumes database objects don't have case-sensitive names
     {% call statement("last_modified", fetch_result=True) %}
         {% for db, db_resources in resources.items() %}
@@ -54,7 +54,7 @@ upstream_prod_prefer_recent is set to true but this feature is incompatible with
 {% endmacro %}
 
 
-{% macro databricks__get_table_update_ts(resources) %}
+{% macro databricks__query_table_last_altered(resources) %}
     {# Flatten resources from all databases and schemas into a single list #}
     {% set all_resources = [] %}
     {% for db, db_resources in resources.items() %}
@@ -93,7 +93,7 @@ upstream_prod_prefer_recent is set to true but this feature is incompatible with
 {% endmacro %}
 
 
-{% macro bigquery__get_table_update_ts(resources) %}
+{% macro bigquery__query_table_last_altered(resources) %}
     {% call statement("last_modified", fetch_result=True) %}
         {# BigQuery requires querying per-schema, so we union all across schemas #}
         {# Flatten into a single list to allow clean loop.last usage #}
@@ -116,9 +116,9 @@ upstream_prod_prefer_recent is set to true but this feature is incompatible with
                 inf_sch.table_schema as schema,
                 inf_sch.table_name as name,
                 coalesce(
-                    timestamp_millis(meta.last_modified_time), 
+                    timestamp_millis(meta.last_modified_time),
                     inf_sch.creation_time
-                ) as last_altered 
+                ) as last_altered
             from `{{ schema_group.database }}.{{ schema_group.schema }}.INFORMATION_SCHEMA.TABLES` inf_sch
             left join `{{ schema_group.database }}.{{ schema_group.schema }}.__TABLES__` meta
                 on inf_sch.table_catalog = meta.project_id

--- a/macros/ref.sql
+++ b/macros/ref.sql
@@ -61,14 +61,22 @@
         {% set return_rel = prod_rel %}
 
         {% if prod_exists is true %}
-            -- When option enabled, return the mostly recently updated of dev & prod relations
+            -- When option enabled, return the most recently updated of dev & prod relations
             {% if prefer_recent is true and dev_exists is true %}
-                -- Find when dev & prod relations were last updated
                 {% set parent_name = parent_node["alias"] or parent_node["name"] %}
-                {% set cached_resource = graph["_upstream_prod_cache"][parent_node["package_name"] ~ "." ~ parent_name] %}
+                {% set parent_resource = parent_node["package_name"] ~ "." ~ parent_name %}
+
+                -- Use cache when available; otherwise query information_schema directly for this model pair
+                {% if "_upstream_prod_cache" in graph and parent_resource in graph["_upstream_prod_cache"] %}
+                    {% set cached_resource = graph["_upstream_prod_cache"][parent_resource] %}
+                {% else %}
+                    {% set to_check = {} %}
+                    {{ upstream_prod.add_node_to_check(to_check, parent_node, prod_rel_db, prod_rel_schema, prod_rel_name, parent_resource, parent_name) }}
+                    {% set cached_resource = upstream_prod.get_node_timestamps(to_check).get(parent_resource) %}
+                {% endif %}
 
                 -- Return dev relation if it exists and is fresher than prod
-                {% if cached_resource["dev"]["last_altered"] | string > cached_resource["prod"]["last_altered"] | string %}
+                {% if cached_resource is not none and cached_resource["dev"]["last_altered"] | string > cached_resource["prod"]["last_altered"] | string %}
                     {{ log("[" ~ current_model ~ "] " ~ parent_ref.table ~ " fresher in dev than prod, switching to dev relation", info=True) }}
                     {% set return_rel = dev_rel %}
                 {% endif %}


### PR DESCRIPTION
## Background

Fixes an error when previewing a model via the dbt Power User VS Code extension with `upstream_prod_prefer_recent: true`:

```
'dict object' has no attribute '_upstream_prod_cache' > in macro ref (macros/ref.sql) > called by macro ref (macros/ref.sql) > called by sql_operation t_c999d8345b064188b461300609f31b3a (from remote system.sql)
```

dbt Power User doesn't reliably trigger the [on-run-start hook](https://github.com/LewisDavies/upstream-prod/blob/8f2542f180f47863e9655c061a2195853fb2962c/dbt_project.yml#L14) that populates the cache, so the ref macro is trying to look up a non-existent key.

This PR partially restores the behaviour in versions < 0.10.0 of the package. The on-run-start hook is still the preferred option as it more performant, but there's now also a fallback lookup in the `ref` macro itself. This combines the old and new approaches and should guarantee the `prefer_recent` lookup works in all setups.

Other changes:
- Refactoring after adding the fallback. Lots of potentially repeated code is moved into macros, some of which were renamed for clarity.
- The platform loop has been moved from `Makefile` to `run_tests.sh`, so all the platforms and projects are controlled in one place.
- The output of `run_tests.sh` has been cleaned up so it's far easier to read.

## Checklist

- [ ] Checked `ref` parameters are consistent across the primary macro, test projects & README
- [ ] Added `is not undefined` alongside `is not none` for properties that aren't always added to the graph
- [ ] Added tests if necessary
- [x] Passed integration tests
- [x] Checked installation instructions
- [x] Bumped package version
