### PR TITLE
Add backup query results to graph

### DIFF
--- a/macros/ref.sql
+++ b/macros/ref.sql
@@ -73,6 +73,13 @@
                     {% set to_check = {} %}
                     {{ upstream_prod.add_node_to_check(to_check, parent_node, prod_rel_db, prod_rel_schema, prod_rel_name, parent_resource, parent_name) }}
                     {% set cached_resource = upstream_prod.get_node_timestamps(to_check).get(parent_resource) %}
+                    -- Persist to graph cache so subsequent refs to the same parent skip the query
+                    {% if "_upstream_prod_cache" not in graph %}
+                        {% do graph.update({"_upstream_prod_cache": {}}) %}
+                    {% endif %}
+                    {% if cached_resource is not none %}
+                        {% do graph["_upstream_prod_cache"].update({parent_resource: cached_resource}) %}
+                    {% endif %}
                 {% endif %}
 
                 -- Return dev relation if it exists and is fresher than prod


### PR DESCRIPTION
## Background

## Checklist

- [ ] Checked `ref` parameters are consistent across the primary macro, test projects & README
- [ ] Added `is not undefined` alongside `is not none` for properties that aren't always added to the graph
- [ ] Added tests if necessary
- [x] Passed integration tests
- [ ] Checked installation instructions
- [ ] Bumped package version
