### PR TITLE
Generalise populate_cache macro

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -11,4 +11,4 @@ clean-targets: # directories to be removed by `dbt clean`
   - "target"
   - "dbt_packages"
 
-on-run-start: '{{ populate_cache() }}'
+on-run-start: '{{ populate_cache(selected_resources) }}'

--- a/macros/find_model_node.sql
+++ b/macros/find_model_node.sql
@@ -6,7 +6,7 @@
 
     {% if execute is true %}
         {% set matching_nodes = [] %}
-        {% for n in graph.nodes.values() if n["name"] == model %}
+        {% for n in graph.nodes.values() if model in [n["name"], n["alias"]] %}
             {% if project is none or project == n["package_name"] %}
                 {% if version is not none %}
                     {% if n["version"] == version %}

--- a/macros/populate_cache.sql
+++ b/macros/populate_cache.sql
@@ -1,24 +1,24 @@
-{% macro populate_cache() %}
-    {{ return(adapter.dispatch("populate_cache", "upstream_prod")()) }}
+{% macro populate_cache(nodes) %}
+    {{ return(adapter.dispatch("populate_cache", "upstream_prod")(nodes)) }}
 {% endmacro %}
 
-{% macro default__populate_cache() %}
+{% macro default__populate_cache(nodes) %}
 
-    {% if execute 
+    {% if execute
         and var("upstream_prod_enabled", True)
         and var("upstream_prod_prefer_recent", False)
         and target.name not in var("upstream_prod_disabled_targets", [])
     %}
-    {# Raise error if at least one required variable is not set #}
-    {{ upstream_prod.check_reqd_vars(var("upstream_prod_database", None), var("upstream_prod_schema", None), var("upstream_prod_env_schemas", False), env_dbs=var("upstream_prod_env_dbs", False)) }}
+        {# Raise error if at least one required variable is not set #}
+        {{ upstream_prod.check_reqd_vars(var("upstream_prod_database", None), var("upstream_prod_schema", None), var("upstream_prod_env_schemas", False), env_dbs=var("upstream_prod_env_dbs", False)) }}
 
         {# Find parents of selected models #}
         {% set to_check = {} %}
-        {% for resource in selected_resources %}
+        {% for resource in nodes %}
             {% set node = graph.nodes[resource] %}
             {% for parent in node.depends_on.nodes %}
                 {# Find parent models excluding those selected on the current run #}
-                {% if parent.startswith("model.") and parent not in selected_resources %}
+                {% if parent.startswith("model.") and parent not in nodes %}
                     {# Find parent on the graph to get relation info #}
                     {% set parent_node = graph.nodes[parent] %}
                     {% set parent_name = parent_node["alias"] or parent_node["name"] %}
@@ -35,7 +35,10 @@
         this pattern to appear in real models. #}
         {% if to_check | length > 0 %}
             {# Persist timestamps on the graph for the rest of the run #}
-            {% do graph.update({"_upstream_prod_cache": upstream_prod.get_node_timestamps(to_check)}) %}
+            {% if "_upstream_prod_cache" not in graph %}
+                {% do graph.update({"_upstream_prod_cache": {}}) %}
+            {% endif %}
+            {% do graph["_upstream_prod_cache"].update(upstream_prod.get_node_timestamps(to_check)) %}
         {% endif %}
 
     {% endif %}

--- a/macros/ref.sql
+++ b/macros/ref.sql
@@ -66,26 +66,19 @@
                 {% set parent_name = parent_node["alias"] or parent_node["name"] %}
                 {% set parent_resource = parent_node["package_name"] ~ "." ~ parent_name %}
 
-                -- Use cache when available; otherwise query information_schema directly for this model pair
-                {% if "_upstream_prod_cache" in graph and parent_resource in graph["_upstream_prod_cache"] %}
-                    {% set cached_resource = graph["_upstream_prod_cache"][parent_resource] %}
-                {% else %}
-                    {% set to_check = {} %}
-                    {{ upstream_prod.add_node_to_check(to_check, parent_node, prod_rel_db, prod_rel_schema, prod_rel_name, parent_resource, parent_name) }}
-                    {% set cached_resource = upstream_prod.get_node_timestamps(to_check).get(parent_resource) %}
-                    -- Persist to graph cache so subsequent refs to the same parent skip the query
-                    {% if "_upstream_prod_cache" not in graph %}
-                        {% do graph.update({"_upstream_prod_cache": {}}) %}
-                    {% endif %}
-                    {% if cached_resource is not none %}
-                        {% do graph["_upstream_prod_cache"].update({parent_resource: cached_resource}) %}
-                    {% endif %}
+                -- Populate cache for all parents of this model on cache miss
+                {% if "_upstream_prod_cache" not in graph or parent_resource not in graph["_upstream_prod_cache"] %}
+                    {% set this_node = upstream_prod.find_model_node(current_model, None, None) %}
+                    {{ upstream_prod.populate_cache([this_node["unique_id"]]) }}
                 {% endif %}
 
                 -- Return dev relation if it exists and is fresher than prod
-                {% if cached_resource is not none and cached_resource["dev"]["last_altered"] | string > cached_resource["prod"]["last_altered"] | string %}
-                    {{ log("[" ~ current_model ~ "] " ~ parent_ref.table ~ " fresher in dev than prod, switching to dev relation", info=True) }}
-                    {% set return_rel = dev_rel %}
+                {% if "_upstream_prod_cache" in graph and parent_resource in graph["_upstream_prod_cache"] %}
+                    {% set cached_resource = graph["_upstream_prod_cache"][parent_resource] %}
+                    {% if cached_resource["dev"]["last_altered"] | string > cached_resource["prod"]["last_altered"] | string %}
+                        {{ log("[" ~ current_model ~ "] " ~ parent_ref.table ~ " fresher in dev than prod, switching to dev relation", info=True) }}
+                        {% set return_rel = dev_rel %}
+                    {% endif %}
                 {% endif %}
             {% endif %}
         {% elif dev_exists %}


### PR DESCRIPTION
## Background

Generalise `populate_cache` so it can be used an `on-run-start` hook and in `ref`.

When `upstream_prod_prefer_recent` is enabled:
- The hook will be triggered on `run` and `build` commands. This is the most efficient route.
- When `compile` is used `populate_cache` checks the update timestamps of all parent nodes and add the results to the cache. This means there's less chance of the same node being checked multiple times on the same run (it may still happen when multiple threads are used).

## Checklist

- [ ] Checked `ref` parameters are consistent across the primary macro, test projects & README
- [ ] Added `is not undefined` alongside `is not none` for properties that aren't always added to the graph
- [ ] Added tests if necessary
- [x] Passed integration tests
- [ ] Checked installation instructions
- [ ] Bumped package version
