### PR TITLE
Better sample and empty handling

### DIFF
--- a/integration_tests/run_tests.sh
+++ b/integration_tests/run_tests.sh
@@ -39,25 +39,25 @@ do
         echo "  Project: $project"
 
         echo "    Setting up..."
-        dbt clean
-        dbt deps
-        dbt run-operation create_test_db --args '{db: upproddb}'
-        dbt run-operation create_test_db --args '{db: updevdb}'
+        dbt clean -t dev
+        dbt deps -t dev
+        dbt run-operation create_test_db -t dev --args '{db: upproddb}'
+        dbt run-operation create_test_db -t dev --args '{db: updevdb}'
 
         echo "    Running staging models..."
         dbt snapshot -t prod
-        dbt run -s stg__defer_prod stg__defer_vers stg__dev_newer stg__cross_project stg__microbatch -t prod
-        dbt run -s stg__dev_fallback stg__dev_newer
+        dbt run -t prod -s stg__defer_prod stg__defer_vers stg__dev_newer stg__cross_project stg__microbatch
+        dbt run -t dev -s stg__dev_fallback stg__dev_newer
 
         echo "    Building downstream models..."
         # event-time flags only affect the microbatch model
-        dbt build -s models/marts --event-time-start "2025-01-01" --event-time-end "2025-01-03"
+        dbt build -t dev -s models/marts --event-time-start "2025-01-01" --event-time-end "2025-01-03"
 
         echo "    Checking --empty flag..."
-        dbt build -s defer_prod --empty
+        dbt build -t dev -s defer_prod --empty
 
         echo "    Checking codegen output..."
-        dbt run-operation generate_model_yaml --args '{"model_names": [stg__defer_prod]}' > /dev/null
+        dbt run-operation generate_model_yaml -t dev --args '{"model_names": [stg__defer_prod]}' > /dev/null
 
         echo "  Done in $((SECONDS - start))s"
     done

--- a/macros/ref.sql
+++ b/macros/ref.sql
@@ -93,20 +93,9 @@
             {{ upstream_prod.raise_ref_not_found_error(current_model, prod_rel_db, prod_rel_schema, prod_rel_name) }}
         {% endif %}
 
-        -- Adjust output if --empty flag was used
-        {% if flags.EMPTY %}
-            {{ return("(select * from " ~ return_rel ~ " where 0=1 limit 0)") }}
-        -- Add filter for microbatch models or when --sample is used
-        {% elif parent_ref.event_time_filter is not none and parent_ref.event_time_filter is not undefined %}
-            {% set filt = parent_ref.event_time_filter %}
-            {{ return(
-                "(select * from " ~ return_rel ~ " where cast(" ~
-                filt.field_name ~ " as " ~ dbt.type_timestamp() ~ ") >= cast('" ~ filt.start ~ "' as " ~ dbt.type_timestamp() ~ ") and cast(" ~ 
-                filt.field_name ~ " as " ~ dbt.type_timestamp() ~ ") < cast('" ~ filt.end ~ "' as " ~ dbt.type_timestamp() ~ "))"
-            ) }}
-        {% else %}
-            {{ return(return_rel) }}
-        {% endif %}
+        -- Carry over limit (--empty) and event_time_filter (microbatch/--sample) from the builtin ref
+        {% set return_rel = return_rel.replace(limit=parent_ref.limit, event_time_filter=parent_ref.event_time_filter) %}
+        {{ return(return_rel) }}
 
     {% endif %}
 {% endmacro %}


### PR DESCRIPTION
## Background

- Add the original `limit` and `event_time_filter` values to the returned ref
- Add targets to commands to override any env vars

## Checklist

- [ ] Checked `ref` parameters are consistent across the primary macro, test projects & README
- [ ] Added `is not undefined` alongside `is not none` for properties that aren't always added to the graph
- [ ] Added tests if necessary
- [x] Passed integration tests
- [ ] Checked installation instructions
- [ ] Bumped package version
