### PR TITLE
Respect config(alias=...) when resolving prod relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add `upstream_prod` to `packages.yml`, then run `dbt deps`:
 # packages.yml
 packages:
   - package: LewisDavies/upstream_prod
-    version: 0.10.2
+    version: 0.10.3
 ```
 
 ### 2. Does your project have a custom schema macro?

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: "upstream_prod"
-version: "0.10.2"
+version: "0.10.3"
 config-version: 2
 
 require-dbt-version: [">=1.5.0", "<3.0.0"]

--- a/integration_tests/models/marts/_marts_models.yml
+++ b/integration_tests/models/marts/_marts_models.yml
@@ -1,6 +1,52 @@
 version: 2
 
 models:
+  - name: aliased
+    columns:
+      # Source
+      - name: source_target
+        tests:
+          - accepted_values:
+              arguments:
+                values: "{{ var('prod_target') }}"
+      - name: source_database
+        tests:
+          - accepted_values:
+              arguments:
+                values: "{{ var('prod_database') }}"
+      - name: source_schema
+        tests:
+          - accepted_values:
+              arguments:
+                values: "{{ var('prod_stg_schema') }}"
+      - name: source_model
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['stg__aliased_renamed']
+      # This
+      - name: this_target
+        tests:
+          - accepted_values:
+              arguments:
+                values: "{{ var('dev_target') }}"
+      - name: this_database
+        tests:
+          - accepted_values:
+              arguments:
+                values: "{{ var('dev_database') }}"
+      - name: this_schema
+        tests:
+          - accepted_values:
+              arguments:
+                values: "{{ var('dev_marts_schema') }}"
+      - name: this_model
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['aliased']
+
+
   - name: cross_project
     columns:
       # Source
@@ -116,8 +162,8 @@ models:
           - accepted_values:
               arguments:
                 values: ['stg__defer_prod']
-          # This specific model has a relationship test because the upstream model is materialised
-          # in prod, not dev
+          # Relationships test confirms the ref resolved to a queryable relation.
+          # The other tests only check literal values baked in when the upstream was built.
           - relationships:
               arguments:
                 to: ref("stg__defer_prod")

--- a/integration_tests/models/marts/aliased.sql
+++ b/integration_tests/models/marts/aliased.sql
@@ -1,0 +1,14 @@
+-- Refs a prod-only staging model with a persistent config(alias=...).
+-- Tests that get_prod_relation uses the alias rather than the filename when
+-- looking up an aliased model in prod.
+select
+    source_target,
+    source_database,
+    source_schema,
+    source_model,
+    '{{ target.name }}' as this_target,
+    '{{ this.database }}' as this_database,
+    '{{ this.schema }}' as this_schema,
+    '{{ this.name }}' as this_model
+from
+    {{ ref('stg__aliased') }}

--- a/integration_tests/models/staging/stg__aliased.sql
+++ b/integration_tests/models/staging/stg__aliased.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        alias="stg__aliased_renamed",
+    )
+}}
+
+select
+    '{{ target.name }}' as source_target,
+    '{{ this.database }}' as source_database,
+    '{{ this.schema }}' as source_schema,
+    '{{ this.name }}' as source_model

--- a/integration_tests/run_tests.sh
+++ b/integration_tests/run_tests.sh
@@ -46,7 +46,7 @@ do
 
         echo "    Running staging models..."
         dbt snapshot -t prod
-        dbt run -t prod -s stg__defer_prod stg__defer_vers stg__dev_newer stg__cross_project stg__microbatch
+        dbt run -t prod -s stg__aliased stg__defer_prod stg__defer_vers stg__dev_newer stg__cross_project stg__microbatch
         dbt run -t dev -s stg__dev_fallback stg__dev_newer
 
         echo "    Building downstream models..."

--- a/macros/get_prod_relation.sql
+++ b/macros/get_prod_relation.sql
@@ -41,14 +41,19 @@
         {% set parent_database = prod_database or dev_database %}
     {% endif %}
 
-    /***************    
-    prod_rel_name helps the package find the correct prod relation for projects using a custom 
-    generate_alias_name macro. It assumes that custom aliases are only used in dev envs and prod
-    relations always have the same name as the model (+ version suffix when needed).
-    It's hacky but it seems to work. 
+    /***************
+    prod_rel_name identifies the correct prod relation. There are two cases:
+    1. A persistent `config(alias=...)` on the model — the alias is the real name in both
+       environments, so we use it directly.
+    2. Otherwise — the alias may be a dev-only override set by a custom `generate_alias_name`
+       macro, so we fall back to the filename (+ version suffix when needed).
     ***************/
     {% set re = modules.re %}
-    {% set prod_rel_name = re.search("\w+(?=\.)", parent_node.path).group() %}
+    {% if parent_node.config.alias is not none %}
+        {% set prod_rel_name = parent_node.config.alias %}
+    {% else %}
+        {% set prod_rel_name = re.search("\w+(?=\.)", parent_node.path).group() %}
+    {% endif %}
 
     {{ return([parent_database, parent_schema, prod_rel_name]) }}
 


### PR DESCRIPTION
## Background

get_prod_relation derived `prod_rel_name` from the file path, which only works when aliases are dev-only overrides produced by a custom `generate_alias_name` macro. Models with a persistent `config(alias=...)` resolved to the filename in prod, which doesn't exist — the package fell back to the dev relation with a "not found in prod" log message, even though the aliased relation existed in prod all along.

Prefer `parent_node.config.alias` when set; fall back to the path-derived name otherwise. Add an integration test that refs a prod-only staging model with `config(alias=...)` and asserts the upstream was resolved to prod.

## Checklist

- [ ] Checked `ref` parameters are consistent across the primary macro, test projects & README
- [ ] Added `is not undefined` alongside `is not none` for properties that aren't always added to the graph
- [x] Added tests if necessary
- [x] Passed integration tests
- [ ] Checked installation instructions
- [x] Bumped package version
- [x] Updated package version in README install snippet
