### PR TITLE
Update get_prod_relation.sql

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: "upstream_prod"
-version: "0.10.3"
+version: "0.10.4"
 config-version: 2
 
 require-dbt-version: [">=1.5.0", "<3.0.0"]

--- a/macros/get_prod_relation.sql
+++ b/macros/get_prod_relation.sql
@@ -35,8 +35,16 @@
 
     -- Set prod database name
     {% if env_dbs is true %}
-        -- Database generated with custom macro
-        {% set parent_database = generate_database_name(prod_database, parent_node, True) | trim %}
+        {% set custom_database_name = parent_node.config.database %}
+        -- Database generated with custom macro.
+        -- If no custom database is set on the node, fall back to prod_database
+        -- (upstream_prod_database var) so nodes in the default prod DB are found,
+        -- mirroring the schema fallback pattern above.
+        {% if custom_database_name is none and prod_database is not none %}
+            {% set parent_database = prod_database %}
+        {% else %}
+            {% set parent_database = generate_database_name(custom_database_name, parent_node, True) | trim %}
+        {% endif %}
     {% else %}
         {% set parent_database = prod_database or dev_database %}
     {% endif %}


### PR DESCRIPTION
## Background

## Checklist

- [x] Checked `ref` parameters are consistent across the primary macro, test projects & README
- [x] Added `is not undefined` alongside `is not none` for properties that aren't always added to the graph
- [ ] Added tests if necessary
- [ ] Passed integration tests
- [x] Checked installation instructions
- [x] Bumped package version
- [ ] Updated package version in README install snippet

I just mirrored the pattern a bit for the schemas - we have a scenario where we have multiple prod DBs - prod for staging/int tables and then the actual PROD db that read only users/reporting tools can see.
