### PR TITLE
Fix logic for seeds and snapshots

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ All logic lives in `macros/`. The package works by overriding dbt's built-in `re
 | `get_prod_relation.sql` | Resolves the prod database/schema/name for a given node |
 | `find_model_node.sql` | Looks up a node in `graph.nodes` by model name |
 | `find_selected_nodes.sql` | Returns the set of models selected in the current run |
-| `populate_cache.sql` | `on-run-start` hook — pre-fetches timestamps for all unselected parent nodes and stores them in `graph["_upstream_prod_cache"]` |
+| `populate_cache.sql` | `on-run-start` hook — pre-fetches timestamps for all unselected parent nodes (models, seeds, snapshots) and stores them in `graph["_upstream_prod_cache"]` |
 | `query_table_last_altered.sql` | Adapter-dispatched SQL — queries `information_schema` for `last_altered` timestamps. Returns a raw result set. |
 | `get_node_timestamps.sql` | Calls `query_table_last_altered`, parses result rows into `{resource: {env: {database, schema, name, last_altered}}}` |
 | `add_node_to_check.sql` | Mutates a `to_check` dict in place to add dev and prod entries for a single node (shared between `populate_cache` and the `ref` slow path) |
@@ -31,7 +31,7 @@ All logic lives in `macros/`. The package works by overriding dbt's built-in `re
 
 When `upstream_prod_prefer_recent: true` is set:
 
-1. `populate_cache` runs via `on-run-start`, querying timestamps for all unselected parent models and storing them in `graph["_upstream_prod_cache"]`.
+1. `populate_cache` runs via `on-run-start`, querying timestamps for all unselected parent nodes (models, seeds, snapshots) and storing them in `graph["_upstream_prod_cache"]`.
 2. In `ref.sql`, if both dev and prod relations exist and the cache contains an entry for the parent, the cached timestamps determine which relation to return.
 3. **Cache miss** (e.g. `dbt compile`, dbt Power User preview, or stale cache from a long-running process): `ref.sql` falls back to a live `get_node_timestamps` call for just that one model pair.
 
@@ -56,6 +56,22 @@ Tests live in `integration_tests/`. The test runner:
 3. Builds staging models in prod, then downstream models in dev, then asserts correct relation resolution
 
 `dbt_project_files/` configs tested: `dev_db`, `dev_db_dev_sch`, `dev_db_env_sch`, `dev_sch`, `env_dbs`, `env_sch`.
+
+## Running integration tests safely
+
+`make test` runs `integration_tests/run_tests.sh`, which calls `create_test_db` for two hardcoded database names: `upproddb` and `updevdb`. This macro is **destructive** by design:
+
+- Snowflake: `create or replace database upproddb` (drops the existing one)
+- Databricks: `drop catalog if exists upproddb cascade; create catalog upproddb`
+- BigQuery: drops every schema in `upproddb` and `updevdb` via `drop schema ... cascade`
+
+Before running `make test` against your warehouse:
+
+1. **Use a sandbox account / project** with no production data. Verify nothing important lives under the names `upproddb` or `updevdb`.
+2. **Run `make debug-<platform>`** first (e.g. `make debug-bigquery`) to confirm connectivity without touching any databases.
+3. **The test runner deletes everything it owns by name on each run.** This is intentional — each test config rebuilds from scratch — but unforgiving if you mis-target it.
+
+If you only want to test a single adapter, use the platform-specific target: `make test-snowflake`, `make test-databricks`, `make test-bigquery`.
 
 ## Environment
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: "upstream_prod"
-version: "0.10.3"
+version: "0.10.4"
 config-version: 2
 
 require-dbt-version: [">=1.5.0", "<3.0.0"]

--- a/integration_tests/dbt_project_files/dev_db.yml
+++ b/integration_tests/dbt_project_files/dev_db.yml
@@ -28,6 +28,11 @@ snapshots:
     +strategy: timestamp
     +updated_at: updated_at
 
+seeds:
+  upstream_prod_integration_tests:
+    +static_analysis: off
+    +schema: seeds
+
 vars:
   # Package config
   upstream_prod_database: upproddb
@@ -39,10 +44,12 @@ vars:
   prod_database: ["upproddb"]
   prod_stg_schema: ["prod_stg"]
   prod_snapshots_schema: ["prod_snapshots"]
+  prod_seeds_schema: ["prod_seeds"]
   dev_target: ["dev"]
   dev_database: ["updevdb"]
   dev_marts_schema: ["prod_marts"]
   dev_stg_schema: ["prod_stg"]
+  dev_seeds_schema: ["prod_seeds"]
 
 flags:
   require_generic_test_arguments_property: true

--- a/integration_tests/dbt_project_files/dev_db_dev_sch.yml
+++ b/integration_tests/dbt_project_files/dev_db_dev_sch.yml
@@ -28,6 +28,11 @@ snapshots:
     +strategy: timestamp
     +updated_at: updated_at
 
+seeds:
+  upstream_prod_integration_tests:
+    +static_analysis: off
+    +schema: seeds
+
 vars:
   # Package config
   upstream_prod_database: upproddb
@@ -40,10 +45,12 @@ vars:
   prod_database: ["upproddb"]
   prod_stg_schema: ["prod_stg"]
   prod_snapshots_schema: ["prod_snapshots"]
+  prod_seeds_schema: ["prod_seeds"]
   dev_target: ["dev"]
   dev_database: ["updevdb"]
   dev_marts_schema: ["dev_marts"]
   dev_stg_schema: ["dev_stg"]
+  dev_seeds_schema: ["dev_seeds"]
 
 flags:
   require_generic_test_arguments_property: true

--- a/integration_tests/dbt_project_files/dev_db_env_sch.yml
+++ b/integration_tests/dbt_project_files/dev_db_env_sch.yml
@@ -28,6 +28,11 @@ snapshots:
     +strategy: timestamp
     +updated_at: updated_at
 
+seeds:
+  upstream_prod_integration_tests:
+    +static_analysis: off
+    +schema: seeds
+
 vars:
   # Package config
   upstream_prod_database: upproddb
@@ -40,10 +45,12 @@ vars:
   prod_database: ["upproddb"]
   prod_stg_schema: ["stg"]
   prod_snapshots_schema: ["snapshots"]
+  prod_seeds_schema: ["seeds"]
   dev_target: ["dev"]
   dev_database: ["updevdb"]
   dev_marts_schema: ["dev"]
   dev_stg_schema: ["dev"]
+  dev_seeds_schema: ["dev"]
 
 flags:
   require_generic_test_arguments_property: true

--- a/integration_tests/dbt_project_files/dev_sch.yml
+++ b/integration_tests/dbt_project_files/dev_sch.yml
@@ -28,6 +28,11 @@ snapshots:
     +strategy: timestamp
     +updated_at: updated_at
 
+seeds:
+  upstream_prod_integration_tests:
+    +static_analysis: off
+    +schema: seeds
+
 vars:
   # Package config
   upstream_prod_schema: prod  
@@ -39,10 +44,12 @@ vars:
   prod_database: ["upproddb"]
   prod_stg_schema: ["prod_stg"]
   prod_snapshots_schema: ["prod_snapshots"]
+  prod_seeds_schema: ["prod_seeds"]
   dev_target: ["dev"]
   dev_database: ["upproddb"]
   dev_marts_schema: ["dev_marts"]
   dev_stg_schema: ["dev_stg"]
+  dev_seeds_schema: ["dev_seeds"]
 
 flags:
   require_generic_test_arguments_property: true

--- a/integration_tests/dbt_project_files/env_dbs.yml
+++ b/integration_tests/dbt_project_files/env_dbs.yml
@@ -28,6 +28,11 @@ snapshots:
     +strategy: timestamp
     +updated_at: updated_at
 
+seeds:
+  upstream_prod_integration_tests:
+    +static_analysis: off
+    +schema: seeds
+
 vars:
   # Package config
   upstream_prod_database: upproddb
@@ -40,10 +45,12 @@ vars:
   prod_database: ["upproddb"]
   prod_stg_schema: ["prod_stg"]
   prod_snapshots_schema: ["prod_snapshots"]
+  prod_seeds_schema: ["prod_seeds"]
   dev_target: ["dev"]
   dev_database: ["updevdb"]
   dev_marts_schema: ["prod_marts"]
   dev_stg_schema: ["prod_stg"]
+  dev_seeds_schema: ["prod_seeds"]
 
 flags:
   require_generic_test_arguments_property: true

--- a/integration_tests/dbt_project_files/env_sch.yml
+++ b/integration_tests/dbt_project_files/env_sch.yml
@@ -28,6 +28,11 @@ snapshots:
     +strategy: timestamp
     +updated_at: updated_at
 
+seeds:
+  upstream_prod_integration_tests:
+    +static_analysis: off
+    +schema: seeds
+
 vars:
   # Package config
   upstream_prod_env_schemas: true
@@ -39,10 +44,12 @@ vars:
   prod_database: ["upproddb"]
   prod_stg_schema: ["stg"]
   prod_snapshots_schema: ["snapshots"]
+  prod_seeds_schema: ["seeds"]
   dev_target: ["dev"]
   dev_database: ["upproddb"]
   dev_marts_schema: ["dev"]
   dev_stg_schema: ["dev"]
+  dev_seeds_schema: ["dev"]
 
 flags:
   require_generic_test_arguments_property: true

--- a/integration_tests/models/marts/_marts_models.yml
+++ b/integration_tests/models/marts/_marts_models.yml
@@ -487,3 +487,85 @@ models:
           - accepted_values:
               arguments:
                 values: ['snapshot_example']
+
+
+  - name: defer_prod_seed
+    columns:
+      # Source
+      - name: source_database
+        tests:
+          - accepted_values:
+              arguments:
+                values: "{{ var('prod_database') }}"
+      - name: source_schema
+        tests:
+          - accepted_values:
+              arguments:
+                values: "{{ var('prod_seeds_schema') }}"
+      - name: source_model
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['seed__defer_prod']
+      # This
+      - name: this_target
+        tests:
+          - accepted_values:
+              arguments:
+                values: "{{ var('dev_target') }}"
+      - name: this_database
+        tests:
+          - accepted_values:
+              arguments:
+                values: "{{ var('dev_database') }}"
+      - name: this_schema
+        tests:
+          - accepted_values:
+              arguments:
+                values: "{{ var('dev_marts_schema') }}"
+      - name: this_model
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['defer_prod_seed']
+
+
+  - name: dev_newer_seed
+    columns:
+      # Source
+      - name: source_database
+        tests:
+          - accepted_values:
+              arguments:
+                values: "{{ var('dev_database') }}"
+      - name: source_schema
+        tests:
+          - accepted_values:
+              arguments:
+                values: "{{ var('dev_seeds_schema') }}"
+      - name: source_model
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['seed__dev_newer']
+      # This
+      - name: this_target
+        tests:
+          - accepted_values:
+              arguments:
+                values: "{{ var('dev_target') }}"
+      - name: this_database
+        tests:
+          - accepted_values:
+              arguments:
+                values: "{{ var('dev_database') }}"
+      - name: this_schema
+        tests:
+          - accepted_values:
+              arguments:
+                values: "{{ var('dev_marts_schema') }}"
+      - name: this_model
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['dev_newer_seed']

--- a/integration_tests/models/marts/defer_prod_seed.sql
+++ b/integration_tests/models/marts/defer_prod_seed.sql
@@ -1,10 +1,10 @@
 {% set rel = ref('seed__defer_prod') %}
 select
-    '{{ rel.database }}'   as source_database,
-    '{{ rel.schema }}'     as source_schema,
-    '{{ rel.identifier }}' as source_model,
-    '{{ target.name }}'    as this_target,
-    '{{ this.database }}'  as this_database,
-    '{{ this.schema }}'    as this_schema,
-    '{{ this.name }}'      as this_model
+    '{{ rel.database | lower }}'   as source_database,
+    '{{ rel.schema | lower }}'     as source_schema,
+    '{{ rel.identifier | lower }}' as source_model,
+    '{{ target.name }}'            as this_target,
+    '{{ this.database }}'          as this_database,
+    '{{ this.schema }}'            as this_schema,
+    '{{ this.name }}'              as this_model
 from {{ rel }}

--- a/integration_tests/models/marts/defer_prod_seed.sql
+++ b/integration_tests/models/marts/defer_prod_seed.sql
@@ -1,0 +1,10 @@
+{% set rel = ref('seed__defer_prod') %}
+select
+    '{{ rel.database }}'   as source_database,
+    '{{ rel.schema }}'     as source_schema,
+    '{{ rel.identifier }}' as source_model,
+    '{{ target.name }}'    as this_target,
+    '{{ this.database }}'  as this_database,
+    '{{ this.schema }}'    as this_schema,
+    '{{ this.name }}'      as this_model
+from {{ rel }}

--- a/integration_tests/models/marts/dev_newer_seed.sql
+++ b/integration_tests/models/marts/dev_newer_seed.sql
@@ -1,10 +1,10 @@
 {% set rel = ref('seed__dev_newer') %}
 select
-    '{{ rel.database }}'   as source_database,
-    '{{ rel.schema }}'     as source_schema,
-    '{{ rel.identifier }}' as source_model,
-    '{{ target.name }}'    as this_target,
-    '{{ this.database }}'  as this_database,
-    '{{ this.schema }}'    as this_schema,
-    '{{ this.name }}'      as this_model
+    '{{ rel.database | lower }}'   as source_database,
+    '{{ rel.schema | lower }}'     as source_schema,
+    '{{ rel.identifier | lower }}' as source_model,
+    '{{ target.name }}'            as this_target,
+    '{{ this.database }}'          as this_database,
+    '{{ this.schema }}'            as this_schema,
+    '{{ this.name }}'              as this_model
 from {{ rel }}

--- a/integration_tests/models/marts/dev_newer_seed.sql
+++ b/integration_tests/models/marts/dev_newer_seed.sql
@@ -1,0 +1,10 @@
+{% set rel = ref('seed__dev_newer') %}
+select
+    '{{ rel.database }}'   as source_database,
+    '{{ rel.schema }}'     as source_schema,
+    '{{ rel.identifier }}' as source_model,
+    '{{ target.name }}'    as this_target,
+    '{{ this.database }}'  as this_database,
+    '{{ this.schema }}'    as this_schema,
+    '{{ this.name }}'      as this_model
+from {{ rel }}

--- a/integration_tests/run_tests.sh
+++ b/integration_tests/run_tests.sh
@@ -44,6 +44,10 @@ do
         dbt run-operation create_test_db -t dev --args '{db: upproddb}'
         dbt run-operation create_test_db -t dev --args '{db: updevdb}'
 
+        echo "    Seeding test seeds..."
+        dbt seed -t prod -s seed__defer_prod seed__dev_newer
+        dbt seed -t dev -s seed__dev_newer
+
         echo "    Running staging models..."
         dbt snapshot -t prod
         dbt run -t prod -s stg__aliased stg__defer_prod stg__defer_vers stg__dev_newer stg__cross_project stg__microbatch

--- a/integration_tests/seeds/seed__defer_prod.csv
+++ b/integration_tests/seeds/seed__defer_prod.csv
@@ -1,0 +1,2 @@
+id,val
+1,hello

--- a/integration_tests/seeds/seed__dev_newer.csv
+++ b/integration_tests/seeds/seed__dev_newer.csv
@@ -1,0 +1,2 @@
+id,val
+1,hello

--- a/macros/populate_cache.sql
+++ b/macros/populate_cache.sql
@@ -17,7 +17,7 @@
             {% set parent_ids = [] %}
             {% for resource in selected_resources %}
                 {% for parent in graph.nodes[resource].depends_on.nodes %}
-                    {% if parent.startswith("model.") and parent not in selected_resources %}
+                    {% if parent.split(".")[0] in ("model", "seed", "snapshot") and parent not in selected_resources %}
                         {% do parent_ids.append(parent) %}
                     {% endif %}
                 {% endfor %}

--- a/macros/query_table_last_altered.sql
+++ b/macros/query_table_last_altered.sql
@@ -94,20 +94,44 @@ upstream_prod_prefer_recent is set to true but this feature is incompatible with
 
 
 {% macro bigquery__query_table_last_altered(resources) %}
-    {% call statement("last_modified", fetch_result=True) %}
-        {# BigQuery requires querying per-schema, so we union all across schemas #}
-        {# Flatten into a single list to allow clean loop.last usage #}
-        {% set flat_schemas = [] %}
-        {% for db, db_resources in resources.items() %}
-            {% for schema, schema_resources in db_resources.items() %}
+    {# BigQuery requires querying per-schema (no database-wide INFORMATION_SCHEMA.TABLES),
+       and errors when the queried dataset does not exist. Probe INFORMATION_SCHEMA.SCHEMATA
+       first per database, then build the union only over (db, schema) pairs that exist. #}
+    {% set existing_schemas = {} %}
+    {% for db in resources.keys() %}
+        {% set schemata_query %}
+            select schema_name from `{{ db }}`.INFORMATION_SCHEMA.SCHEMATA
+        {% endset %}
+        {% set schemata_result = run_query(schemata_query) %}
+        {% set names = [] %}
+        {% if schemata_result is not none %}
+            {% for row in schemata_result %}
+                {% do names.append(row[0] | lower) %}
+            {% endfor %}
+        {% endif %}
+        {% do existing_schemas.update({db: names}) %}
+    {% endfor %}
+
+    {% set flat_schemas = [] %}
+    {% for db, db_resources in resources.items() %}
+        {% for schema, schema_resources in db_resources.items() %}
+            {% if schema | lower in existing_schemas.get(db, []) %}
                 {% do flat_schemas.append({
                     "database": db,
                     "schema": schema,
                     "resources": schema_resources
                 }) %}
-            {% endfor %}
+            {% endif %}
         {% endfor %}
+    {% endfor %}
 
+    {# If none of the parent envs have a dataset yet (e.g. first run before any seed/snapshot
+       has been built in dev), there are no timestamps to look up. #}
+    {% if flat_schemas | length == 0 %}
+        {{ return(None) }}
+    {% endif %}
+
+    {% call statement("last_modified", fetch_result=True) %}
         {% for schema_group in flat_schemas %}
             select
                 rm.resource,

--- a/macros/ref.sql
+++ b/macros/ref.sql
@@ -73,7 +73,7 @@
                     {% set all_parents = model.depends_on.nodes if (model is defined and model.depends_on is defined) else [parent_node["unique_id"]] %}
                     {% set parent_ids = [] %}
                     {% for p in all_parents %}
-                        {% if p.startswith("model.") %}
+                        {% if p.split(".")[0] in ("model", "seed", "snapshot") %}
                             {% do parent_ids.append(p) %}
                         {% endif %}
                     {% endfor %}


### PR DESCRIPTION
## Background

Seeds and snapshots were being excluded following the rewrite in version 0.10.0. This surfaced an issue with the `query_table_last_altered` macro, which could break in BigQuery when we try to check the relations in a non-existent schema.

## Checklist

- [ ] Checked `ref` parameters are consistent across the primary macro, test projects & README
- [ ] Added `is not undefined` alongside `is not none` for properties that aren't always added to the graph
- [x] Added tests if necessary
- [x] Passed integration tests
- [ ] Checked installation instructions
- [x] Bumped package version
- [ ] Updated package version in README install snippet
