### PR TITLE
Show dbt flavor in test runner output

### DIFF
--- a/integration_tests/import_project/dbt_project.yml
+++ b/integration_tests/import_project/dbt_project.yml
@@ -14,7 +14,7 @@ clean-targets:
 
 models:
   import_project:
-    +static_analysis: unsafe
+    +static_analysis: strict
     staging:
       +schema: stg
 

--- a/integration_tests/run_tests.sh
+++ b/integration_tests/run_tests.sh
@@ -20,11 +20,23 @@ else
     platforms="sf dbx bq"
 fi
 
+# Report which dbt is on PATH so the user knows whether they're testing core or fusion
+dbt_version=$(dbt --version 2>&1)
+case "$dbt_version" in
+    *[Ff]usion*) dbt_flavor="dbt-fusion" ;;
+    *[Cc]ore*)   dbt_flavor="dbt-core" ;;
+    *)
+        echo "Error: could not determine dbt flavor from 'dbt --version':" >&2
+        echo "$dbt_version" >&2
+        exit 1
+        ;;
+esac
+
 for platform in $platforms
 do
     echo ""
     echo "========================================"
-    echo "  Platform: $(platform_name $platform)"
+    echo "  Platform: $(platform_name $platform) ($dbt_flavor)"
     echo "========================================"
 
     export UP_TARGET_PLATFORM=$platform


### PR DESCRIPTION
## Summary
- Test runner detects whether `dbt` on PATH is dbt-core or dbt-fusion via `dbt --version` and annotates each platform banner: `Platform: Snowflake (dbt-core)` or `(dbt-fusion)`. Repeated per-platform so it's hard to miss which flavor a run actually exercised. Bails with the raw version output if neither pattern matches.
- Flips `static_analysis: unsafe → strict` on the `import_project` so Fusion's static analysis runs during integration tests.

This is groundwork for a follow-up PR that adds Fusion `--sample` / `--empty` support to `macros/ref.sql`; having the runner make the active flavor obvious avoids the "I thought I was testing core but I was actually on fusion" footgun.

## Test plan
- [x] `make test-snowflake` against dbt-core prints `Platform: Snowflake (dbt-core)` and runs to completion.
- [x] Repeat with `dbt` resolving to dbt-fusion and confirm the banner reads `(dbt-fusion)`.
- [ ] Confirm the error path fires when `dbt --version` doesn't mention either flavor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)