### PR TITLE
Support --sample and microbatch on dbt Fusion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,14 @@ Before running `make test` against your warehouse:
 
 If you only want to test a single adapter, use the platform-specific target: `make test-snowflake`, `make test-databricks`, `make test-bigquery`.
 
+## Bumping the package version
+
+The `version` in `dbt_project.yml` should always be exactly **one ahead** of the latest tag on `origin`. Before changing it:
+
+1. Run `git tag --sort=-v:refname | head -1` to see the latest released version.
+2. The next version (current + a single bump on the appropriate segment) is the only correct value for `dbt_project.yml`. Don't bump again just because work has happened since the previous bump — if the in-progress version still matches `latest_tag + 1`, leave it alone.
+3. Never bump because `dbt_project.yml`'s version "feels stale". A version that hasn't been released yet is still the right value.
+
 ## Environment
 
 Copy `.env.example` to `.env` and fill in credentials before running tests. Python deps managed with `uv` (`make setup`).

--- a/README.md
+++ b/README.md
@@ -8,11 +8,17 @@ In a typical project, prod and dev models are materialised in [separate environm
 
 `upstream-prod` solves this by intelligently redirecting `ref`s to prod outputs. It is highly adaptable and can be used whether your environments are in separate schemas, databases, or a combination of both. On most warehouses it can even compare dev and prod outputs and use the most recently-updated relation.
 
-### ⚠️ Breaking changes in version `0.9.0`
+### Known limitations
 
-If upgrading from an earlier version:
-- Your `ref` macro *must* be updated by copying [this example](#5-create-a-custom-ref-macro).
-- Projects using the deprecated `upstream_prod_database_replace` variable should follow the setup guide to use `upstream_prod_env_dbs` instead.
+**`microbatch` on Snowflake with dbt Fusion is supported but may be fragile.** Fusion's microbatch handling is still a work in progress. It doesn't apply batch filters to refs the way dbt-core does ([dbt-labs/dbt-fusion#1608](https://github.com/dbt-labs/dbt-fusion/issues/1608)), so `upstream-prod` reconstructs the filter manually from `model.batch` and the parent's `event_time`. This works on Snowflake Fusion today, but it leans on Fusion-internal state with no stability guarantees and could break in future Fusion releases.
+
+**Don't use `microbatch` on Databricks / BigQuery Fusion.** Builds crash inside the adapter's incremental materialization (`adapter.clean_sql(model['compiled_code'])` resolves to undefined during the per-batch render). This reproduces with a vanilla microbatch model — no `upstream-prod` involvement — so it's an upstream Fusion gap rather than something `upstream-prod` can patch around. Exclude microbatch from your Fusion runs:
+
+```bash
+dbt run --exclude config.incremental_strategy:microbatch
+```
+
+Microbatch with `upstream-prod` works fully on dbt-core for every supported adapter.
 
 ## Setup
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: "upstream_prod"
-version: "0.10.4"
+version: "0.10.3"
 config-version: 2
 
 require-dbt-version: [">=1.5.0", "<3.0.0"]

--- a/integration_tests/models/marts/_marts_models.yml
+++ b/integration_tests/models/marts/_marts_models.yml
@@ -432,15 +432,36 @@ models:
 
 
   - name: microbatch
+    tests:
+      - row_count_equals:
+          arguments:
+            expected: 2
     columns:
       - name: activity_date
         tests:
           - not_null
           - dbt_utils.not_constant
+          - accepted_values:
+              arguments:
+                values: ['2025-01-01', '2025-01-02']
       - name: updated_at
         tests:
           - not_null
           - dbt_utils.not_constant
+
+
+  - name: sample_flag
+    tests:
+      - row_count_equals:
+          arguments:
+            expected: 1
+    columns:
+      - name: activity_date
+        tests:
+          - not_null
+          - dbt_utils.expression_is_true:
+              arguments:
+                expression: ">= {{ dbt.dateadd('hour', -36, dbt.current_timestamp()) }} and activity_date <= {{ dbt.dateadd('hour', -12, dbt.current_timestamp()) }}"
 
 
   - name: snapshot_example

--- a/integration_tests/models/marts/microbatch.sql
+++ b/integration_tests/models/marts/microbatch.sql
@@ -10,7 +10,7 @@
 
 {{
     config(
-        materialized = "incremental",
+        materialized="incremental",
         incremental_strategy="microbatch",
         event_time="activity_date",
         batch_size="day",
@@ -18,8 +18,6 @@
         partition_by=partition
     )
 }}
-
-  
 
 select
     activity_date,

--- a/integration_tests/models/marts/sample_flag.sql
+++ b/integration_tests/models/marts/sample_flag.sql
@@ -1,0 +1,2 @@
+select activity_date
+from {{ ref('stg__sample_flag') }}

--- a/integration_tests/models/staging/stg__sample_flag.sql
+++ b/integration_tests/models/staging/stg__sample_flag.sql
@@ -1,0 +1,7 @@
+{{ config(event_time="activity_date") }}
+
+-- One row inside a typical --sample window, one row well outside.
+-- Dates are dynamic so the test stays correct as time passes.
+select {{ dbt.dateadd('day', -1, dbt.current_timestamp()) }} as activity_date
+union all
+select {{ dbt.dateadd('day', -30, dbt.current_timestamp()) }} as activity_date

--- a/integration_tests/run_tests.sh
+++ b/integration_tests/run_tests.sh
@@ -62,15 +62,27 @@ do
 
         echo "    Running staging models..."
         dbt snapshot -t prod
-        dbt run -t prod -s stg__aliased stg__defer_prod stg__defer_vers stg__dev_newer stg__cross_project stg__microbatch
+        dbt run -t prod -s stg__aliased stg__defer_prod stg__defer_vers stg__dev_newer stg__cross_project stg__microbatch stg__sample_flag
         dbt run -t dev -s stg__dev_fallback stg__dev_newer
+
+        # microbatch builds crash inside dbt-databricks / dbt-bigquery Fusion
+        # materializations (see README "Known limitations"). Reproduces without
+        # upstream-prod, so we exclude it from all Fusion runs.
+        # sample_flag is built separately below since it requires --sample.
+        excludes="sample_flag"
+        if [ "$dbt_flavor" = "dbt-fusion" ]; then
+            excludes="$excludes config.incremental_strategy:microbatch"
+        fi
 
         echo "    Building downstream models..."
         # event-time flags only affect the microbatch model
-        dbt build -t dev -s models/marts --event-time-start "2025-01-01" --event-time-end "2025-01-03"
+        dbt build -t dev -s models/marts --exclude "$excludes" --event-time-start "2025-01-01" --event-time-end "2025-01-03"
 
         echo "    Checking --empty flag..."
         dbt build -t dev -s defer_prod --empty
+
+        echo "    Checking --sample flag..."
+        dbt build -t dev -s sample_flag --sample='3 days'
 
         echo "    Checking --inline flag..."
         dbt show -t dev --inline 'select * from {{ ref("stg__dev_newer") }}' --limit 5 > /dev/null

--- a/integration_tests/tests/generic/row_count_equals.sql
+++ b/integration_tests/tests/generic/row_count_equals.sql
@@ -1,0 +1,5 @@
+{% test row_count_equals(model, expected) %}
+    select 1 as failure
+    from (select count(*) as n from {{ model }}) c
+    where c.n != {{ expected }}
+{% endtest %}

--- a/macros/ref.sql
+++ b/macros/ref.sql
@@ -101,9 +101,40 @@
             {{ upstream_prod.raise_ref_not_found_error(current_model, prod_rel_db, prod_rel_schema, prod_rel_name) }}
         {% endif %}
 
-        -- Carry over limit (--empty) and event_time_filter (microbatch/--sample) from the builtin ref
-        {% set return_rel = return_rel.replace(limit=parent_ref.limit, event_time_filter=parent_ref.event_time_filter) %}
-        {{ return(return_rel) }}
+        -- Core: replace() carries over limit (--empty) and event_time_filter (microbatch/--sample) from the builtin ref.
+        -- This method is not available on Fusion.
+        {% if return_rel.replace is defined %}
+            {% set return_rel = return_rel.replace(limit=parent_ref.limit, event_time_filter=parent_ref.event_time_filter) %}
+            {{ return(return_rel) }}
+        -- Fusion microbatch: model.batch is populated during materialization but Fusion does not
+        -- bake the batch filter onto parent_ref (the relevant code path in dbt-fusion's RefFunction
+        -- is wired up via with_microbatch_context, which has no callers). Reconstruct the filter
+        -- ourselves from model.batch and the parent model's event_time.
+        {% elif model is defined
+            and model.batch is defined
+            and model.batch.id
+            and parent_node["event_time"] is defined
+            and parent_node["event_time"] is not none
+        %}
+            {% set event_time = parent_node["event_time"] %}
+            {{ return(
+                "(select * from " ~ return_rel ~ " where cast(" ~
+                event_time ~ " as " ~ dbt.type_timestamp() ~ ") >= cast('" ~ model.batch.event_time_start ~ "' as " ~ dbt.type_timestamp() ~ ") and cast(" ~
+                event_time ~ " as " ~ dbt.type_timestamp() ~ ") < cast('" ~ model.batch.event_time_end ~ "' as " ~ dbt.type_timestamp() ~ "))"
+            ) }}
+        -- Fusion --sample / --empty: parent_ref's str form contains the active filter via
+        -- render_with_run_filter. Swap the dev path for the prod path inside that rendered string.
+        -- When no filter is active parent_str == parent_ref.render(), so we return the relation
+        -- to keep macros like dbt_utils.union_relations() working.
+        {% else %}
+            {% set parent_rendered = parent_ref.render() %}
+            {% set parent_str = parent_ref | string %}
+            {% if parent_str == parent_rendered %}
+                {{ return(return_rel) }}
+            {% else %}
+                {{ return(parent_str.replace(parent_rendered, return_rel.render())) }}
+            {% endif %}
+        {% endif %}
 
     {% endif %}
 {% endmacro %}


### PR DESCRIPTION
## Summary

Adds Fusion support to `upstream-prod`'s `ref()` override. Fusion's `RelationObject` doesn't expose `.replace()`, so the existing path (which carried `--empty` / `--sample` / microbatch filters forward via `parent_ref.replace(limit=…, event_time_filter=…)`) silently no-op'd under Fusion. The dispatch is now three branches:

1. **dbt-core** — unchanged `.replace()` path.
2. **Fusion microbatch** — `model.batch` is populated during materialization but Fusion doesn't bake the batch filter onto `parent_ref` (`with_microbatch_context` has no callers anywhere in the dbt-fusion source). Reconstruct the filter manually from `model.batch.event_time_start/end` + the parent's `event_time` column.
3. **Fusion `--sample` / `--empty`** — `parent_ref | string` on Fusion routes through `Display::render_with_run_filter` and includes the active `RunFilter` (sample/empty/etc.). Substitute the dev path for the prod path inside that rendered string. When no filter is active, `parent_str == parent_ref.render()` and we return the bare relation so callers like `dbt_utils.union_relations()` still work.

## Test coverage additions

- `models/staging/stg__sample_flag.sql` + `models/marts/sample_flag.sql` — dynamic-date pair (1 day ago + 30 days ago) for direct `--sample='3 days'` testing.
- `tests/generic/row_count_equals.sql` — small reusable generic test.
- yaml assertions in `_marts_models.yml`:
  - `sample_flag`: `row_count_equals: 1` plus `dbt_utils.expression_is_true` window check (12h–36h ago) to verify the sample filter was applied.
  - `microbatch`: `row_count_equals: 2` and `accepted_values: ['2025-01-01', '2025-01-02']` on `activity_date` to lock in exact batch contents.
- Runner exercises `--sample` directly via `dbt build -s sample_flag --sample='3 days'`.

## Fusion microbatch limitation

Fusion's microbatch support is still being built out:
- On **Databricks / BigQuery Fusion**, any microbatch build crashes inside the adapter's incremental materialization (`adapter.clean_sql(model['compiled_code'])` resolves to undefined during the per-batch render). This reproduces with a vanilla microbatch model — no `upstream-prod` involvement — so it's an upstream Fusion gap. Confirmed via four targeted experiments (string return, bare-relation diagnostic, non-microbatch strategy, full upstream-prod bypass).
- On **Snowflake Fusion**, microbatch runs but Fusion itself doesn't apply source-side batch filters to refs (see [dbt-labs/dbt-core#14525](https://github.com/dbt-labs/dbt-core/issues/14525)). Branch 2 of this PR's `ref.sql` is what supplies the missing filter.

The runner excludes `config.incremental_strategy:microbatch` from Fusion runs, and README "Known limitations" documents both the Snowflake fragility and the Databricks/BigQuery crash.

## Other changes

- Reverts a premature `dbt_project.yml` version bump (`0.10.4` → `0.10.3` — `0.10.3` was never tagged on `origin`).
- Adds a CLAUDE.md note to check the latest released tag before bumping the version.

## Test plan

- [x] `make test` (all six projects × Snowflake / Databricks / BigQuery under dbt-fusion) — passes.
- [x] Earlier verification against dbt-core on Snowflake — passes.
- [x] Repeat dbt-core sweep on Snowflake / Databricks / BigQuery before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)