### PR TITLE
Skip non-node resources in populate_cache on dbt Fusion

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: "upstream_prod"
-version: "0.10.3"
+version: "0.10.4"
 config-version: 2
 
 require-dbt-version: [">=1.5.0", "<3.0.0"]

--- a/macros/populate_cache.sql
+++ b/macros/populate_cache.sql
@@ -12,15 +12,20 @@
         {# Raise error if at least one required variable is not set #}
         {{ upstream_prod.check_reqd_vars(var("upstream_prod_database", None), var("upstream_prod_schema", None), var("upstream_prod_env_schemas", False), env_dbs=var("upstream_prod_env_dbs", False)) }}
 
-        {# Default: derive parents from selected_resources (on-run-start path) #}
+        {# Default: derive parents from selected_resources (on-run-start path).
+           Guard with `resource in graph.nodes`: dbt-fusion excludes analyses
+           from graph.nodes (dbt-core includes them), and strict Jinja errors
+           on the missing-key lookup. #}
         {% if parent_ids is none %}
             {% set parent_ids = [] %}
             {% for resource in selected_resources %}
-                {% for parent in graph.nodes[resource].depends_on.nodes %}
-                    {% if parent.split(".")[0] in ("model", "seed", "snapshot") and parent not in selected_resources %}
-                        {% do parent_ids.append(parent) %}
-                    {% endif %}
-                {% endfor %}
+                {% if resource in graph.nodes %}
+                    {% for parent in graph.nodes[resource].depends_on.nodes %}
+                        {% if parent.split(".")[0] in ("model", "seed", "snapshot") and parent not in selected_resources %}
+                            {% do parent_ids.append(parent) %}
+                        {% endif %}
+                    {% endfor %}
+                {% endif %}
             {% endfor %}
         {% endif %}
 


### PR DESCRIPTION
## Summary

- dbt-fusion omits analyses from `graph.nodes` (dbt-core kept them in), and its strict Jinja errors on the missing-key lookup instead of returning Undefined. This crashed the `populate_cache` on-run-start hook when `upstream_prod_prefer_recent` was enabled and any analysis was in the selection.
- Guard the parent-derivation loop with `if resource in graph.nodes` so unknown resource types are skipped rather than crashing the run.
- Bump to 0.10.4.

## Test plan

- [x] Reproduced against dbt-fusion 2.0.0-preview.176 in a real project — debug logging confirmed two `analysis.*` IDs were the missing keys.
- [x] With the guard applied, `dbtf compile --write-catalog` proceeds past the `upstream_prod-on_run_start-0` hook.
- [ ] CI integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)